### PR TITLE
fix(cleanup): skip inventory_sources deletion and fix progress display

### DIFF
--- a/src/aap_migration/cli/commands/cleanup.py
+++ b/src/aap_migration/cli/commands/cleanup.py
@@ -43,6 +43,7 @@ NON_DELETABLE_RESOURCES = [
     "role_definitions",  # System-managed roles cannot be deleted (400: Role is managed by the system)
     "role_user_assignments",  # Assignments are removed when the role/user/resource is deleted
     "role_team_assignments",  # Assignments are removed when the role/team/resource is deleted
+    "inventory_sources",  # Automatically removed when their parent inventory is deleted
 ]
 
 
@@ -1264,12 +1265,25 @@ async def delete_resources(
                 f"(max_concurrent={max_concurrent})..."
             )
 
+            # Wrap the callback so the pre-filter skipped_count is always included.
+            # delete_resources_parallel tracks its own local skipped (PendingDeletionError)
+            # starting from 0, which would reset the live display's Skip counter.
+            if progress_callback and skipped_count > 0:
+                _pre_skipped = skipped_count
+
+                def _parallel_cb(del_cnt: int, skip_cnt: int, err_cnt: int) -> None:
+                    progress_callback(del_cnt, _pre_skipped + skip_cnt, err_cnt)
+
+                parallel_callback: Callable[[int, int, int], None] | None = _parallel_cb
+            else:
+                parallel_callback = progress_callback
+
             deleted, _, errors, failed = await delete_resources_parallel(
                 client,
                 endpoint,
                 resources_to_delete,
                 config,
-                progress_callback=progress_callback,
+                progress_callback=parallel_callback,
             )
 
             deleted_count = deleted

--- a/src/aap_migration/reporting/live_progress.py
+++ b/src/aap_migration/reporting/live_progress.py
@@ -592,26 +592,30 @@ class MigrationProgressDisplay:
             state = self.phase_states[phase_id]
             task_id = self.phase_tasks[phase_id]
 
-            # Mark the specific phase's task as complete
-            # When explicitly completed, always show as complete (✓) unless there were errors
+            # complete_phase is an explicit end-of-phase signal: always force ✓ 100%.
+            # We cannot rely on state.status_text here because concurrent callbacks
+            # from delete_resources_parallel may have left total_processed < total_items
+            # (e.g. the rendering thread captures a mid-progress frame), causing
+            # status_text to return "running" and the spinner to persist.
             total_processed = state.completed + state.skipped + state.failed
-            final_status = state.status_text
-            final_color = state.status_color
 
-            # Handle zero-export case (REQ-005)
-            # If nothing was processed but we expected items, show a warning instead of complete
+            # Only warn if truly nothing happened on a non-empty phase
             if total_processed == 0 and state.total_items > 0:
                 final_status = "complete_with_issues"
                 final_color = MigrationColors.WARNING
-
-            # If no items were tracked but phase is explicitly completed, force complete status
-            if final_status == "pending":
+            elif state.failed > 0:
+                final_status = "complete_with_issues"
+                final_color = MigrationColors.WARNING
+            else:
                 final_status = "complete"
                 final_color = MigrationColors.COMPLETE
 
+            # Force completed = total_items so the bar reaches 100% regardless of
+            # how many callbacks fired before this call.
             self.phase_progress.update(
                 task_id,
-                completed=total_processed,
+                completed=state.total_items,
+                total=state.total_items,
                 status_text=final_status,
                 status=f"[{final_color}]{final_status}[/{final_color}]",
                 metrics=state.formatted_metrics,


### PR DESCRIPTION
- Add inventory_sources to NON_DELETABLE_RESOURCES since AAP cascade-deletes them when their parent inventory is deleted, making explicit deletion unnecessary and leaving confusing 0/N entries.

- Wrap progress_callback passed to delete_resources_parallel so the pre-filter skipped_count is always included in live updates; the parallel function starts its own skipped counter at 0 which was silently resetting the Skip display mid-phase.

- Fix complete_phase to always force completed=total_items and status_text="complete" (unless errors). Previously it derived the final status from state.status_text, which could return "running" when concurrent callbacks left total_processed < total_items, causing the spinner to persist in the final rendered output.

Made-with: Cursor

Fixes https://github.com/redhat-cop/aap-bridge/issues/15.