### PR TITLE
updating to clarify controller API endpoint for the migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ cp .env.example .env
 
 Edit `.env` with your AAP instance details and database connection string.
 
-**Critical AAP 2.6 Note:** The Target URL must point to the **Platform Gateway** (`/api/controller/v2`), not the direct controller API.
+**Critical AAP 2.6 Note:** The Target URL must point to the **Platform's Controller** (`/api/controller/v2`), not the Gateway API.
 
 ```bash
 


### PR DESCRIPTION
It's not clear whether the URL for the destination AAP should be the controller API or the Gateway API. 

Doing a grep shows that it is consistently however the controller API, thus I updated the README.md to reflect the same. 

Let me know if this is incorrect and I can try to fix it. 

```
grep -r "api/controller" .
./.env.example:# IMPORTANT: Must include /api/controller/v2 path for Platform Gateway
./.env.example:TARGET__URL=https://<target_aap_url>/api/controller/v2
./docs/developer-guide/adding-resource-types.md:- **List:** `GET /api/controller/v2/instances/`
./docs/developer-guide/adding-resource-types.md:- **Create:** `POST /api/controller/v2/instances/`
./docs/developer-guide/adding-resource-types.md:- **Detail:** `GET /api/controller/v2/instances/{id}/`
./docs/developer-guide/adding-resource-types.md:- **Update:** `PATCH /api/controller/v2/instances/{id}/`
./docs/developer-guide/adding-resource-types.md:- **Delete:** `DELETE /api/controller/v2/instances/{id}/`
./docs/developer-guide/architecture.md:- Base URL: `/api/controller/v2/` (Platform Gateway)
./docs/getting-started/configuration.md:TARGET__URL=https://target-aap.example.com/api/controller/v2
./docs/getting-started/quickstart.md:TARGET__URL=https://target-aap.example.com/api/controller/v2
./docs/getting-started/quickstart.md:    For AAP 2.6+, the target URL must use `/api/controller/v2` (Platform
./docs/user-guide/troubleshooting.md:TARGET__URL=https://target-aap.example.com/api/controller/v2
./README.md:AAP 2.6 routes all API calls through the Platform Gateway at `https://<gateway>/api/controller/v2/`. The tool automatically handles this routing.
./src/aap_migration/client/aap_target_client.py:            config: AAP instance configuration (should include /api/controller/v2/ path)
./src/aap_migration/client/aap_target_client.py:        if not base_url.endswith("/api/controller/v2"):
./src/aap_migration/client/aap_target_client.py:            if "/api/controller/v2" in base_url:
./src/aap_migration/client/aap_target_client.py:                base_url = f"{base_url.rstrip('/')}/api/controller/v2"
./src/aap_migration/client/aap_target_client.py:                endpoint = parsed.path.replace("/api/controller/v2/", "")
./src/aap_migration/client/bulk_operations.py:        # Note: AAPTargetClient base_url already includes /api/controller/v2
./src/aap_migration/client/bulk_operations.py:        # Note: AAPTargetClient base_url already includes /api/controller/v2
./src/aap_migration/client/bulk_operations.py:        # Note: AAPTargetClient base_url already includes /api/controller/v2
./src/aap_migration/client/bulk_operations.py:        # Note: AAPTargetClient base_url already includes /api/controller/v2
./src/aap_migration/migration/exporter.py:        marker = "/api/controller/v2/"
./src/aap_migration/migration/exporter.py:        if cleaned.startswith("api/controller/v2/"):
./src/aap_migration/migration/exporter.py:            return cleaned[len("api/controller/v2/") :]
./src/aap_migration/prep/endpoint_discovery.py:            # AAP API returns absolute paths like "/api/v2/ping/" or "/api/controller/v2/organizations/"
./tests/unit/test_context.py:        url="https://target.example.com/api/controller/v2",
./tests/unit/test_inventory_fk.py:        ("/api/controller/v2/inventories/99/", 99),
./tests/unit/test_inventory_fk.py:        ("/api/controller/v2/credentials/10/", 10),
./tests/unit/test_inventory_fk.py:        "related": {"credential": "/api/controller/v2/credentials/10/"},
```