### PR TITLE
fix(schedules): skip system_job schedules on export/import/cleanup, f…

### DIFF
--- a/src/aap_migration/cli/commands/cleanup.py
+++ b/src/aap_migration/cli/commands/cleanup.py
@@ -1206,6 +1206,15 @@ async def delete_resources(
                     skip_resource = True
                     skip_reason = "managed/system instance"
 
+                # Skip schedules that belong to system jobs (built-in maintenance tasks)
+                elif resource_type == "schedules":
+                    ujt_summary = (resource.get("summary_fields") or {}).get(
+                        "unified_job_template"
+                    ) or {}
+                    if ujt_summary.get("unified_job_type") == "system_job":
+                        skip_resource = True
+                        skip_reason = "system_job schedule"
+
             if skip_resource:
                 logger.debug(f"Skipping {skip_reason}: {resource_name} (id={resource_id})")
                 skipped_count += 1

--- a/src/aap_migration/migration/exporter.py
+++ b/src/aap_migration/migration/exporter.py
@@ -1894,8 +1894,9 @@ class ScheduleExporter(ResourceExporter):
     ) -> dict[str, Any] | None:
         """Process schedule resource.
 
-        Note: We no longer skip system schedules here, as we now support mapping
-        system_job_templates. The transformer will handle validation.
+        Skips schedules whose unified_job_template is a system_job — these are
+        built-in maintenance schedules (cleanup jobs, session expiry, etc.) that
+        cannot be meaningfully imported into a target environment.
 
         Args:
             resource: Raw resource data from API
@@ -1904,7 +1905,17 @@ class ScheduleExporter(ResourceExporter):
         Returns:
             Processed resource or None if should be skipped
         """
-        # Call parent processing
+        summary = resource.get("summary_fields") or {}
+        ujt_summary = summary.get("unified_job_template") or {}
+        if ujt_summary.get("unified_job_type") == "system_job":
+            schedule_name = resource.get("name", f"id={resource.get('id')}")
+            logger.debug(
+                "skipping_system_job_schedule",
+                name=schedule_name,
+                ujt_id=ujt_summary.get("id"),
+            )
+            return None
+
         return await super()._process_resource(resource, resource_type)
 
 

--- a/src/aap_migration/migration/transformer.py
+++ b/src/aap_migration/migration/transformer.py
@@ -1967,9 +1967,20 @@ class ScheduleTransformer(DataTransformer):
                 # API types are singular (job_template), our state uses plural (job_templates)
                 api_type = ujt_summary.get("type")
 
-                # Fallback for system jobs where 'type' might be missing but 'unified_job_type' exists
-                if not api_type and ujt_summary.get("unified_job_type") == "system_job":
-                    api_type = "system_job_template"
+                # Fallback when 'type' is absent — derive it from 'unified_job_type'.
+                # Older AAP versions (e.g. 4.x) omit 'type' from summary_fields but
+                # always include 'unified_job_type'.
+                if not api_type:
+                    _unified_job_type_to_api_type = {
+                        "job": "job_template",
+                        "workflow_job": "workflow_job_template",
+                        "project_update": "project",
+                        "inventory_update": "inventory_source",
+                        "system_job": "system_job_template",
+                    }
+                    api_type = _unified_job_type_to_api_type.get(
+                        ujt_summary.get("unified_job_type", "")
+                    )
 
                 if api_type:
                     # Map API type to our internal resource type (usually plural)


### PR DESCRIPTION
…ix UJT type resolution for AAP 4.x

Schedules linked to system_job unified_job_templates (built-in cleanup jobs, session expiry, etc.) are now skipped during export and cleanup.

Also fixes ScheduleTransformer to fall back to unified_job_type when the type field is absent — as is the case on AAP 4.x — so schedules like "Demo Schedule" referencing normal job templates are no longer silently dropped.

Made-with: Cursor

Fixes https://github.com/redhat-cop/aap-bridge/issues/8.