### PR TITLE
fix: remove false warning for cascade-deleted phases in cleanup TUI

### DIFF
--- a/src/aap_migration/reporting/live_progress.py
+++ b/src/aap_migration/reporting/live_progress.py
@@ -618,11 +618,10 @@ class MigrationProgressDisplay:
             # status_text to return "running" and the spinner to persist.
             total_processed = state.completed + state.skipped + state.failed
 
-            # Only warn if truly nothing happened on a non-empty phase
-            if total_processed == 0 and state.total_items > 0:
-                final_status = "complete_with_issues"
-                final_color = MigrationColors.WARNING
-            elif state.failed > 0:
+            # Warn only on real failures. Zero processed with non-zero total_items
+            # is not a warning — it means all resources were already gone (e.g.
+            # cascade-deleted by an earlier phase) which is a successful outcome.
+            if state.failed > 0:
                 final_status = "complete_with_issues"
                 final_color = MigrationColors.WARNING
             else:


### PR DESCRIPTION
When a resource type's items are cascade-deleted by an earlier cleanup phase (e.g. Schedules removed when Job Templates are deleted), the phase count pre-fetched before the loop is stale. delete_resources finds no resources and returns (0,0,0,[]) without firing the progress callback, leaving total_processed=0 while total_items=1. complete_phase was treating this as a warning, showing ⚠ even though nothing actually failed.

Only show ⚠ when state.failed > 0 (real deletion errors).

Made-with: Cursor

Fixes https://github.com/redhat-cop/aap-bridge/issues/26.