### PR TITLE
docs: update repository URL to redhat-cop org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,5 +63,5 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Environment variable support for all credentials
 - No hardcoded secrets in configuration files
 
-[Unreleased]: https://github.com/antonysallas/aap-bridge/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/antonysallas/aap-bridge/releases/tag/v0.1.0
+[Unreleased]: https://github.com/redhat-cop/aap-bridge/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/redhat-cop/aap-bridge/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The tool is organized into several key components:
 
 ```bash
 # Clone the repository
-git clone https://github.com/antonysallas/aap-bridge.git
+git clone https://github.com/redhat-cop/aap-bridge.git
 cd aap-bridge
 
 # Create virtual environment
@@ -398,7 +398,7 @@ For security concerns and vulnerability reporting, please see [SECURITY.md](SECU
 
 ## Support
 
-- **Issues**: Report bugs and request features via [GitHub Issues](https://github.com/antonysallas/aap-bridge/issues)
+- **Issues**: Report bugs and request features via [GitHub Issues](https://github.com/redhat-cop/aap-bridge/issues)
 - **Security**: Report vulnerabilities privately (see [SECURITY.md](SECURITY.md))
 
 ## Acknowledgments

--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing to AAP Bridge!
 ## Code of Conduct
 
 This project follows the [AAP Bridge Code of
-Conduct](https://github.com/antonysallas/aap-bridge/blob/main/CODE_OF_CONDUCT.md).
+Conduct](https://github.com/redhat-cop/aap-bridge/blob/main/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code.
 
 ## How to Contribute

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -23,7 +23,7 @@ Before installing AAP Bridge, ensure you have:
 
 ```bash
 # Clone the repository
-git clone https://github.com/antonysallas/aap-bridge.git
+git clone https://github.com/redhat-cop/aap-bridge.git
 cd aap-bridge
 
 # Create virtual environment
@@ -39,7 +39,7 @@ uv sync
 
 ```bash
 # Clone the repository
-git clone https://github.com/antonysallas/aap-bridge.git
+git clone https://github.com/redhat-cop/aap-bridge.git
 cd aap-bridge
 
 # Create virtual environment
@@ -57,7 +57,7 @@ For contributing or development:
 
 ```bash
 # Clone and setup
-git clone https://github.com/antonysallas/aap-bridge.git
+git clone https://github.com/redhat-cop/aap-bridge.git
 cd aap-bridge
 
 # Use make for complete setup

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,6 @@ This project is licensed under the GNU General Public License v3.0.
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/antonysallas/aap-bridge/issues)
+- **Issues**: [GitHub Issues](https://github.com/redhat-cop/aap-bridge/issues)
 - **Security**: See
-  [SECURITY.md](https://github.com/antonysallas/aap-bridge/blob/main/SECURITY.md)
+  [SECURITY.md](https://github.com/redhat-cop/aap-bridge/blob/main/SECURITY.md)

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -3,7 +3,7 @@
 All notable changes to AAP Bridge are documented here.
 
 For the complete changelog, see
-[CHANGELOG.md](https://github.com/antonysallas/aap-bridge/blob/main/CHANGELOG.md)
+[CHANGELOG.md](https://github.com/redhat-cop/aap-bridge/blob/main/CHANGELOG.md)
 in the repository.
 
 ## Version History

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -324,7 +324,7 @@ logging:
 
 If you can't resolve an issue:
 
-1. Check the [GitHub Issues](https://github.com/antonysallas/aap-bridge/issues)
+1. Check the [GitHub Issues](https://github.com/redhat-cop/aap-bridge/issues)
 2. Search existing issues for similar problems
 3. Open a new issue with:
    - AAP Bridge version

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: AAP Bridge
 site_description: Production-grade migration tool for Ansible Automation Platform
 site_author: Antony Sallas
-repo_url: https://github.com/antonysallas/aap-bridge
-repo_name: antonysallas/aap-bridge
+repo_url: https://github.com/redhat-cop/aap-bridge
+repo_name: redhat-cop/aap-bridge
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,10 +72,10 @@ aap-migrate = "aap_migration.cli.main:main"
 aap-bridge = "aap_migration.cli.main:main"
 
 [project.urls]
-Homepage = "https://github.com/antonysallas/aap-bridge"
-Documentation = "https://github.com/antonysallas/aap-bridge/tree/main/docs"
-Repository = "https://github.com/antonysallas/aap-bridge"
-"Bug Tracker" = "https://github.com/antonysallas/aap-bridge/issues"
+Homepage = "https://github.com/redhat-cop/aap-bridge"
+Documentation = "https://github.com/redhat-cop/aap-bridge/tree/main/docs"
+Repository = "https://github.com/redhat-cop/aap-bridge"
+"Bug Tracker" = "https://github.com/redhat-cop/aap-bridge/issues"
 
 [tool.setuptools]
 package-dir = {"" = "src"}


### PR DESCRIPTION
Replace all references to antonysallas/aap-bridge with redhat-cop/aap-bridge following the upstream repository move.

Made-with: Cursor

Addresses https://github.com/redhat-cop/aap-bridge/issues/18. 