### PR TITLE
fix: mark all migration paths fully supported and standardize messaging

### DIFF
--- a/src/aap_migration/cli/commands/prep.py
+++ b/src/aap_migration/cli/commands/prep.py
@@ -151,6 +151,10 @@ def prep(ctx: MigrationContext, output_dir: Path, force: bool) -> None:
                         echo_success(
                             f"Migration path {source_version} → {target_version}: fully supported"
                         )
+                        if version_path.known_exceptions:
+                            echo_info("  Known exceptions:")
+                            for exc in version_path.known_exceptions:
+                                click.echo(f"    - {exc}")
 
             # ============================================
             # 2. DISCOVER ENDPOINTS (combined output)

--- a/src/aap_migration/resources.py
+++ b/src/aap_migration/resources.py
@@ -47,24 +47,24 @@ COMPATIBILITY_MATRIX: list[VersionPath] = [
         notes="Primary migration path. Fully tested.",
         known_exceptions=[
             "Encrypted credentials cannot be extracted from source API",
-            "Custom credential types require manual pre-creation",
+            "Instance groups referenced by RBAC assignments must exist on the target with the same name",
         ],
     ),
     VersionPath(
         source="2.4",
         target="2.6",
-        status="partial",
-        notes="Core resource families tested. Some 2.4-specific features may require manual steps.",
+        status="supported",
+        notes="Primary migration path. Fully tested.",
         known_exceptions=[
             "Encrypted credentials cannot be extracted from source API",
-            "2.4-specific inventory plugin configurations may need adjustment",
+            "Instance groups referenced by RBAC assignments must exist on the target with the same name",
         ],
     ),
     VersionPath(
         source="2.5",
         target="2.6",
         status="supported",
-        notes="Fully supported. RBAC role definitions and assignments are migrated.",
+        notes="Primary migration path. Fully tested.",
         known_exceptions=[
             "Encrypted credentials cannot be extracted from source API",
             "Instance groups referenced by RBAC assignments must exist on the target with the same name",


### PR DESCRIPTION
- Mark 2.4 → 2.6 as fully supported (previously partial)
- Standardise notes to "Primary migration path. Fully tested." for all three paths (2.3, 2.4, 2.5)
- Replace version-specific known_exceptions with the two universal ones: encrypted credentials and instance groups prerequisite
- Display known_exceptions in prep output for supported paths, not just partial ones

Made-with: Cursor

The former known exceptions have all been addressed.

Fixes: https://github.com/redhat-cop/aap-bridge/issues/16.