### PR TITLE
fix: exclude instances and instance_groups from cleanup phase

### DIFF
--- a/src/aap_migration/cli/commands/cleanup.py
+++ b/src/aap_migration/cli/commands/cleanup.py
@@ -44,6 +44,8 @@ NON_DELETABLE_RESOURCES = [
     "role_user_assignments",  # Assignments are removed when the role/user/resource is deleted
     "role_team_assignments",  # Assignments are removed when the role/team/resource is deleted
     "inventory_sources",  # Automatically removed when their parent inventory is deleted
+    "instances",  # Not managed by this tool; controller nodes must not be deleted
+    "instance_groups",  # Not managed by this tool; must exist as a prerequisite on the target
 ]
 
 


### PR DESCRIPTION
These resource types are not managed by this tool and must not be deleted during cleanup. Instance groups are a documented prerequisite that must exist on the target environment before migration.

Made-with: Cursor

Fixes https://github.com/redhat-cop/aap-bridge/issues/37.