### PR TITLE
feat(hosts): associate hosts with their groups after bulk import

### DIFF
--- a/src/aap_migration/migration/importer.py
+++ b/src/aap_migration/migration/importer.py
@@ -2900,10 +2900,15 @@ class HostImporter(ResourceImporter):
             source_name_by_id: dict[int, str] = {}
             batch_skipped = 0
 
+            source_group_ids_by_source_id: dict[int, list[int]] = {}
+
             for host in batch:
                 source_id = host.pop("_source_id", host.get("id"))
                 source_name = host.get("name", f"host_{source_id}")
                 source_name_by_id[source_id] = source_name
+
+                # Capture group memberships before preparing the bulk payload
+                source_group_ids_by_source_id[source_id] = host.get("_source_group_ids") or []
 
                 # Skip if already migrated
                 if self.state.is_migrated("hosts", source_id):
@@ -2961,6 +2966,45 @@ class HostImporter(ResourceImporter):
                             )
 
                     self.state.batch_create_mappings(mappings)
+
+                    # Associate each created host with its groups
+                    for idx, created_host in enumerate(created_hosts):
+                        if idx >= len(source_info):
+                            break
+                        source_id = source_info[idx]["source_id"]
+                        target_host_id = created_host["id"]
+                        source_group_ids = source_group_ids_by_source_id.get(source_id, [])
+
+                        for source_group_id in source_group_ids:
+                            target_group_id = self.state.get_mapped_id(
+                                "groups", source_group_id
+                            )
+                            if not target_group_id:
+                                logger.debug(
+                                    "host_group_association_skipped_unmapped",
+                                    host_name=created_host.get("name"),
+                                    source_group_id=source_group_id,
+                                )
+                                continue
+                            try:
+                                await self.client.post(
+                                    f"groups/{target_group_id}/hosts/",
+                                    json_data={"id": target_host_id},
+                                )
+                                logger.debug(
+                                    "host_added_to_group",
+                                    host_name=created_host.get("name"),
+                                    target_host_id=target_host_id,
+                                    target_group_id=target_group_id,
+                                )
+                            except Exception as e:
+                                logger.warning(
+                                    "host_group_association_failed",
+                                    host_name=created_host.get("name"),
+                                    target_host_id=target_host_id,
+                                    target_group_id=target_group_id,
+                                    error=str(e),
+                                )
 
                 created_count = len(created_hosts)
                 failed_count = len(failed_hosts)

--- a/src/aap_migration/migration/transformer.py
+++ b/src/aap_migration/migration/transformer.py
@@ -1640,6 +1640,13 @@ class HostTransformer(DataTransformer):
         Returns:
             Transformed host data
         """
+        # Extract source group IDs from summary_fields BEFORE they are removed by
+        # the base transformer.  Stored as _source_group_ids so the importer can
+        # associate each host with its groups after creation.
+        sf_groups = data.get("summary_fields", {}).get("groups", {})
+        group_results = sf_groups.get("results", []) if isinstance(sf_groups, dict) else []
+        data["_source_group_ids"] = [g["id"] for g in group_results if g.get("id")]
+
         # Convert variables to JSON string if needed
         if "variables" in data:
             if isinstance(data["variables"], dict):


### PR DESCRIPTION
After bulk-creating hosts, POST each host to its source groups via groups/<target_group_id>/hosts/ so that inventory group membership is preserved on the target environment.

The HostTransformer now extracts source group IDs from summary_fields.groups before that field is removed, storing them as _source_group_ids on the transformed host. HostImporter.import_hosts_bulk captures these IDs before building the bulk payload, then resolves each source group ID to a target group ID via state mappings and POSTs {"id": <target_host_id>} to the appropriate groups endpoint.

Unmapped groups are skipped at debug level; association failures are logged as warnings without failing the overall import.

Made-with: Cursor

Fixes https://github.com/redhat-cop/aap-bridge/issues/47.