### PR TITLE
feat(groups): export and import nested group hierarchies

### DIFF
--- a/src/aap_migration/migration/exporter.py
+++ b/src/aap_migration/migration/exporter.py
@@ -953,19 +953,38 @@ class InventoryGroupExporter(ResourceExporter):
     Inventory groups can have nested hierarchies (parent-child relationships).
     """
 
+    async def _fetch_child_group_ids(self, group_id: int) -> list[int]:
+        """GET ``groups/<id>/children/`` and return child group source IDs.
+
+        The group list/detail response does not include a top-level ``children``
+        array — it is only accessible via the related endpoint.
+        """
+        endpoint = f"groups/{group_id}/children/"
+        try:
+            rows = await self.client.get_paginated(endpoint, page_size=200)
+        except Exception as e:
+            logger.warning(
+                "group_children_fetch_failed",
+                group_id=group_id,
+                error=str(e),
+            )
+            return []
+        return [row["id"] for row in rows if row.get("id")]
+
     async def export(
         self, filters: dict[str, Any] | None = None
     ) -> AsyncGenerator[dict[str, Any], None]:
-        """Export inventory groups.
+        """Export inventory groups with parent-child relationship data.
 
-        Groups may have parent-child relationships indicated by the 'children' field.
-        Group variables are stored as JSON strings and must be preserved.
+        For each group, fetches ``groups/<id>/children/`` and stores the child
+        source IDs as a ``children`` list so the importer can topologically sort
+        groups and establish nesting via ``POST groups/<parent_id>/children/``.
 
         Args:
             filters: Optional query parameters for filtering
 
         Yields:
-            Inventory group dictionaries
+            Inventory group dictionaries with ``children`` list of source IDs
         """
         logger.info("exporting_inventory_groups")
         async for group in self.export_resources(
@@ -974,6 +993,51 @@ class InventoryGroupExporter(ResourceExporter):
             page_size=self.performance_config.batch_sizes.get("groups", 100),
             filters=filters,
         ):
+            group_id = group.get("id") or group.get("_source_id")
+            if group_id and not group.get("_skipped"):
+                child_ids = await self._fetch_child_group_ids(int(group_id))
+                if child_ids:
+                    group["children"] = child_ids
+                    logger.debug(
+                        "group_children_attached",
+                        group_id=group_id,
+                        group_name=group.get("name"),
+                        child_count=len(child_ids),
+                    )
+            yield group
+
+    async def export_parallel(
+        self,
+        resource_type: str,
+        endpoint: str,
+        page_size: int = 200,
+        max_concurrent_pages: int = 5,
+        filters: dict[str, Any] | None = None,
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Parallel export with children enrichment.
+
+        The CLI uses this path; after each group is yielded from the base
+        parallel fetcher, ``groups/<id>/children/`` is fetched and the child
+        source IDs are attached as a ``children`` list.
+        """
+        async for group in super().export_parallel(
+            resource_type=resource_type,
+            endpoint=endpoint,
+            page_size=page_size,
+            max_concurrent_pages=max_concurrent_pages,
+            filters=filters,
+        ):
+            group_id = group.get("id") or group.get("_source_id")
+            if group_id and not group.get("_skipped"):
+                child_ids = await self._fetch_child_group_ids(int(group_id))
+                if child_ids:
+                    group["children"] = child_ids
+                    logger.debug(
+                        "group_children_attached",
+                        group_id=group_id,
+                        group_name=group.get("name"),
+                        child_count=len(child_ids),
+                    )
             yield group
 
 

--- a/src/aap_migration/migration/importer.py
+++ b/src/aap_migration/migration/importer.py
@@ -1955,6 +1955,11 @@ class InventoryGroupImporter(ResourceImporter):
                     )
                     return {"_skipped": True, "policy_skip": True, "name": data.get("name")}
 
+            # Extract resolved parent ID before creation — the parent-child
+            # relationship is established via POST groups/<parent_id>/children/
+            # after both groups exist, not via a field in the create payload.
+            resolved_parent_id = data.pop("parent", None)
+
             # Use correct API endpoint
             result = await self.client.create_resource(
                 resource_type=api_resource_type,
@@ -1976,6 +1981,28 @@ class InventoryGroupImporter(ResourceImporter):
                 source_id=source_id,
                 target_id=target_id,
             )
+
+            # Assign this group as a child of its parent group
+            if resolved_parent_id:
+                try:
+                    await self.client.post(
+                        f"groups/{resolved_parent_id}/children/",
+                        json_data={"id": target_id},
+                    )
+                    logger.debug(
+                        "group_added_to_parent",
+                        group_name=data.get("name"),
+                        target_group_id=target_id,
+                        target_parent_id=resolved_parent_id,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "group_child_association_failed",
+                        group_name=data.get("name"),
+                        target_group_id=target_id,
+                        target_parent_id=resolved_parent_id,
+                        error=str(e),
+                    )
 
             return result
 


### PR DESCRIPTION
Groups in standard inventories can be nested (parent-child). Previously, the exporter did not fetch child relationships (only accessible via groups/<id>/children/, not inline in the list response), so the importer had no hierarchy data and all groups landed in a single flat tier.

Export: override export_parallel in InventoryGroupExporter to call GET groups/<id>/children/ for each group and attach a children list of source IDs. This mirrors how InventoryExporter enriches constructed inventories with their input_inventories.

Import: in InventoryGroupImporter.import_resource, pop the resolved parent ID from the payload before create_resource (it is not a writable field on the create endpoint), then POST groups/<parent_id>/children/ with {"id": child_id} after the group is created. This mirrors the existing host-to-group association pattern.

Made-with: Cursor

Fixes https://github.com/redhat-cop/aap-bridge/issues/51.