### PR TITLE
feat(notifications): export and import notification template associat…

### DIFF
--- a/src/aap_migration/migration/exporter.py
+++ b/src/aap_migration/migration/exporter.py
@@ -45,6 +45,39 @@ async def _fetch_template_survey_spec(
         return {}
 
 
+async def _fetch_notification_template_ids(
+    client: AAPSourceClient,
+    resource_type: str,
+    resource_id: int,
+    trigger: str,
+) -> list[int]:
+    """GET ``{resource_type}/{id}/notification_templates_{trigger}/`` and return IDs.
+
+    Args:
+        client: Source API client
+        resource_type: e.g. ``"job_templates"`` or ``"workflow_job_templates"``
+        resource_id: Source ID of the template
+        trigger: One of ``"started"``, ``"success"``, ``"error"``, ``"approvals"``
+
+    Returns:
+        List of source notification template IDs assigned to this trigger.
+    """
+    base = get_endpoint(resource_type).rstrip("/")
+    endpoint = f"{base}/{resource_id}/notification_templates_{trigger}/"
+    try:
+        rows = await client.get_paginated(endpoint, page_size=200)
+        return [row["id"] for row in rows if row.get("id")]
+    except Exception as e:
+        logger.warning(
+            "notification_templates_fetch_failed",
+            resource_type=resource_type,
+            resource_id=resource_id,
+            trigger=trigger,
+            error=str(e),
+        )
+        return []
+
+
 @runtime_checkable
 class ExporterProtocol(Protocol):
     """Protocol defining the interface for resource exporters.
@@ -1504,6 +1537,8 @@ class JobTemplateExporter(ResourceExporter):
                 self.client, "job_templates", template["id"]
             )
 
+            await self._attach_notification_template_ids(template, "job_templates")
+
             yield template
 
     async def export_parallel(
@@ -1558,7 +1593,27 @@ class JobTemplateExporter(ResourceExporter):
                 self.client, "job_templates", template["id"]
             )
 
+            await self._attach_notification_template_ids(template, "job_templates")
+
             yield template
+
+    async def _attach_notification_template_ids(
+        self, template: dict[str, Any], resource_type: str
+    ) -> None:
+        """Fetch and attach notification template IDs for all triggers.
+
+        Stores source IDs as ``_nt_started_ids``, ``_nt_success_ids``,
+        and ``_nt_error_ids`` so the importer can re-associate them after
+        creating the template on the target.
+        """
+        tid = template.get("id") or template.get("_source_id")
+        if not tid:
+            return
+        for trigger in ("started", "success", "error"):
+            ids = await _fetch_notification_template_ids(
+                self.client, resource_type, int(tid), trigger
+            )
+            template[f"_nt_{trigger}_ids"] = ids
 
 
 class WorkflowExporter(ResourceExporter):
@@ -1671,6 +1726,8 @@ class WorkflowExporter(ResourceExporter):
                 self.client, "workflow_job_templates", workflow["id"]
             )
 
+            await self._attach_notification_template_ids(workflow, "workflow_job_templates")
+
             yield workflow
 
     async def export_parallel(
@@ -1714,7 +1771,27 @@ class WorkflowExporter(ResourceExporter):
                 self.client, "workflow_job_templates", workflow["id"]
             )
 
+            await self._attach_notification_template_ids(workflow, "workflow_job_templates")
+
             yield workflow
+
+    async def _attach_notification_template_ids(
+        self, workflow: dict[str, Any], resource_type: str
+    ) -> None:
+        """Fetch and attach notification template IDs for all triggers.
+
+        Stores source IDs as ``_nt_started_ids``, ``_nt_success_ids``,
+        ``_nt_error_ids``, and ``_nt_approvals_ids`` so the importer can
+        re-associate them after creating the workflow on the target.
+        """
+        wid = workflow.get("id") or workflow.get("_source_id")
+        if not wid:
+            return
+        for trigger in ("started", "success", "error", "approvals"):
+            ids = await _fetch_notification_template_ids(
+                self.client, resource_type, int(wid), trigger
+            )
+            workflow[f"_nt_{trigger}_ids"] = ids
 
 
 class SystemJobTemplateExporter(ResourceExporter):

--- a/src/aap_migration/migration/importer.py
+++ b/src/aap_migration/migration/importer.py
@@ -855,6 +855,57 @@ class ResourceImporter:
         """
         return self.import_errors.copy()
 
+    async def _associate_notification_templates(
+        self,
+        resource_type: str,
+        target_id: int,
+        source_nt_ids: list[int],
+        trigger: str,
+        template_name: str | None = None,
+    ) -> None:
+        """Associate notification templates with a template via POST.
+
+        Args:
+            resource_type: e.g. ``"job_templates"`` or ``"workflow_job_templates"``
+            target_id: Target template ID
+            source_nt_ids: Source notification template IDs to associate
+            trigger: One of ``"started"``, ``"success"``, ``"error"``, ``"approvals"``
+            template_name: Template name for logging
+        """
+        endpoint = f"{resource_type}/{target_id}/notification_templates_{trigger}/"
+        for source_nt_id in source_nt_ids:
+            target_nt_id = self.state.get_mapped_id("notification_templates", source_nt_id)
+            if not target_nt_id:
+                logger.warning(
+                    "notification_template_mapping_missing",
+                    resource_type=resource_type,
+                    target_id=target_id,
+                    trigger=trigger,
+                    source_nt_id=source_nt_id,
+                    template_name=template_name,
+                )
+                continue
+            try:
+                await self.client.post(endpoint, json_data={"id": target_nt_id})
+                logger.debug(
+                    "notification_template_associated",
+                    resource_type=resource_type,
+                    target_id=target_id,
+                    trigger=trigger,
+                    target_nt_id=target_nt_id,
+                    template_name=template_name,
+                )
+            except Exception as e:
+                logger.warning(
+                    "notification_template_association_failed",
+                    resource_type=resource_type,
+                    target_id=target_id,
+                    trigger=trigger,
+                    target_nt_id=target_nt_id,
+                    template_name=template_name,
+                    error=str(e),
+                )
+
 
 class LabelImporter(ResourceImporter):
     """Importer for label resources."""
@@ -3651,6 +3702,10 @@ class JobTemplateImporter(ResourceImporter):
         survey_spec = data.pop("_survey_spec", None)
         # Extract credentials before import (they're not valid API fields)
         credentials = data.pop("credentials", [])
+        # Extract notification template IDs before import (not valid API fields)
+        nt_ids: dict[str, list[int]] = {}
+        for trigger in ("started", "success", "error"):
+            nt_ids[trigger] = data.pop(f"_nt_{trigger}_ids", []) or []
         template_name = data.get("name")
 
         # Call base import_resource
@@ -3675,6 +3730,11 @@ class JobTemplateImporter(ResourceImporter):
                     survey_spec,
                     template_name=template_name,
                 )
+            for trigger, ids in nt_ids.items():
+                if ids:
+                    await self._associate_notification_templates(
+                        "job_templates", result["id"], ids, trigger, template_name
+                    )
 
         return result
 
@@ -3808,6 +3868,7 @@ class JobTemplateImporter(ResourceImporter):
                 )
 
 
+
 class WorkflowImporter(ResourceImporter):
     """Importer for workflow job template resources."""
 
@@ -3823,18 +3884,30 @@ class WorkflowImporter(ResourceImporter):
         data: dict[str, Any],
         resolve_dependencies: bool = True,
     ) -> dict[str, Any] | None:
-        """Import a workflow; apply ``_survey_spec`` via POST after create."""
+        """Import a workflow; apply ``_survey_spec`` and notification associations via POST after create."""
         survey_spec = data.pop("_survey_spec", None)
+        # Extract notification template IDs before import (not valid API fields)
+        nt_ids: dict[str, list[int]] = {}
+        for trigger in ("started", "success", "error", "approvals"):
+            nt_ids[trigger] = data.pop(f"_nt_{trigger}_ids", []) or []
+        template_name = data.get("name")
+
         result = await super().import_resource(
             resource_type, source_id, data, resolve_dependencies=resolve_dependencies
         )
-        if result and result.get("id") and survey_spec is not None:
-            await self._post_survey_spec_after_create(
-                "workflow_job_templates",
-                result["id"],
-                survey_spec,
-                template_name=result.get("name") or data.get("name"),
-            )
+        if result and result.get("id"):
+            if survey_spec is not None:
+                await self._post_survey_spec_after_create(
+                    "workflow_job_templates",
+                    result["id"],
+                    survey_spec,
+                    template_name=template_name,
+                )
+            for trigger, ids in nt_ids.items():
+                if ids:
+                    await self._associate_notification_templates(
+                        "workflow_job_templates", result["id"], ids, trigger, template_name
+                    )
         return result
 
     async def import_workflows(


### PR DESCRIPTION
…ions

Add export/import of notification template relationships for job templates (started, success, error) and workflow job templates (+ approvals).

- Add _fetch_notification_template_ids() helper to fetch associated NT IDs from the /notification_templates_{trigger}/ sub-endpoints during export
- Enrich JobTemplateExporter and WorkflowExporter to attach _nt_*_ids fields to each exported resource
- Add _associate_notification_templates() to ResourceImporter base class so all importers can POST NT associations after resource creation
- Wire NT association into JobTemplateImporter and WorkflowImporter

Made-with: Cursor

Fixes https://github.com/redhat-cop/aap-bridge/issues/54.