### PR TITLE
fix(credentials): handle same-name credentials with different types

### DIFF
--- a/src/aap_migration/cli/commands/export_import.py
+++ b/src/aap_migration/cli/commands/export_import.py
@@ -1284,7 +1284,15 @@ def import_cmd(
             source_id = resource.get("_source_id")
             if identifier and source_id:
                 resource_identifiers.append(identifier)
-                resource_by_identifier[identifier] = {"source_id": source_id, "data": resource}
+                # Credentials are unique by (name, organization, credential_type) in AAP,
+                # so two credentials can share a name if they have different types.
+                # Use a composite dict key to prevent same-name credentials from
+                # overwriting each other and being silently dropped.
+                if resource_type == "credentials":
+                    dict_key = (identifier, resource.get("credential_type"))
+                else:
+                    dict_key = identifier
+                resource_by_identifier[dict_key] = {"source_id": source_id, "data": resource}
 
         if not resource_identifiers:
             logger.warning(
@@ -1350,7 +1358,16 @@ def import_cmd(
                 # Index by identifier for fast lookup
                 # For organization-scoped resources, use composite key (name, organization)
                 for existing_resource in existing_batch:
-                    if resource_type in ORGANIZATION_SCOPED_RESOURCES:
+                    if resource_type == "credentials":
+                        # Credentials are unique by (name, organization, credential_type).
+                        # Two credentials can share a name when they have different types.
+                        name = existing_resource.get("name")
+                        org = existing_resource.get("organization")
+                        cred_type = existing_resource.get("credential_type")
+                        if name is not None:
+                            key = (name, org, cred_type)
+                            existing_by_identifier[key] = existing_resource
+                    elif resource_type in ORGANIZATION_SCOPED_RESOURCES:
                         # Use (name, organization) as composite key
                         name = existing_resource.get("name")
                         org = existing_resource.get("organization")
@@ -1378,12 +1395,39 @@ def import_cmd(
         found_count = 0
         to_import = []
 
+        # Built-in AAP credential type IDs are stable across environments (same IDs in source
+        # and target).  Custom types (above this threshold) require an ID-mapping lookup.
+        _BUILTIN_CRED_TYPE_MAX_ID = 27
+
         for identifier, resource_info in resource_by_identifier.items():
             source_id = resource_info["source_id"]
             resource_data = resource_info["data"]
 
+            # Derive the plain resource name regardless of whether identifier is a
+            # simple string (most resource types) or a composite tuple (credentials).
+            resource_name = resource_data.get("name") or (
+                identifier[0] if isinstance(identifier, tuple) else identifier
+            )
+
             # Build lookup key based on resource scope
-            if resource_type in ORGANIZATION_SCOPED_RESOURCES:
+            if resource_type == "credentials":
+                # Credentials are unique by (name, organization, credential_type).
+                # Resolve the source credential_type ID to the target ID so the lookup
+                # key matches what was indexed from the target API response.
+                name = resource_data.get("name")
+                org = resource_data.get("organization")
+                source_cred_type_id = resource_data.get("credential_type")
+                if source_cred_type_id is not None:
+                    target_cred_type_id = state.get_mapped_id(
+                        "credential_types", source_cred_type_id
+                    )
+                    if target_cred_type_id is None and source_cred_type_id <= _BUILTIN_CRED_TYPE_MAX_ID:
+                        # Built-in types keep the same ID across environments.
+                        target_cred_type_id = source_cred_type_id
+                else:
+                    target_cred_type_id = None
+                lookup_key = (name, org, target_cred_type_id)
+            elif resource_type in ORGANIZATION_SCOPED_RESOURCES:
                 # For org-scoped resources, use (name, organization) as key
                 name = resource_data.get("name")
                 org = resource_data.get("organization")
@@ -1410,7 +1454,7 @@ def import_cmd(
                     resource_type=mapping_resource_type,
                     source_id=source_id,
                     target_id=existing["id"],
-                    source_name=identifier,
+                    source_name=resource_name,
                     target_name=existing.get(identifier_field),
                 )
 

--- a/src/aap_migration/migration/importer.py
+++ b/src/aap_migration/migration/importer.py
@@ -3232,8 +3232,23 @@ class CredentialImporter(ResourceImporter):
         data.pop("_needs_vault_lookup", None)
 
         try:
-            # Find existing credential in target by name
-            results = await self.client.get("credentials/", params={"name": name})
+            # Find existing credential in target by name AND credential_type.
+            # AAP allows multiple credentials with the same name when they have
+            # different credential types, so we must filter by type to avoid
+            # mapping this credential to the wrong same-name credential.
+            query_params: dict[str, Any] = {"name": name}
+            source_cred_type_id = data.get("credential_type")
+            if source_cred_type_id:
+                target_cred_type_id = self.state.get_mapped_id(
+                    "credential_types", source_cred_type_id
+                )
+                if target_cred_type_id is None and source_cred_type_id <= self.BUILTIN_CREDENTIAL_TYPE_MAX_ID:
+                    # Built-in types keep the same ID across environments.
+                    target_cred_type_id = source_cred_type_id
+                if target_cred_type_id is not None:
+                    query_params["credential_type"] = target_cred_type_id
+
+            results = await self.client.get("credentials/", params=query_params)
             resources = results.get("results", [])
 
             if resources:


### PR DESCRIPTION
AAP allows multiple credentials to share the same name as long as they have different credential types. The precheck and importer treated credentials as unique by (name, org) only, causing one of two same-name credentials to be silently dropped and the other to be mapped/patched against the wrong target credential.

- batch_precheck_resources: key resource_by_identifier by (name, credential_type) for credentials so both entries survive the dict
- batch_precheck_resources: key existing_by_identifier by (name, org, credential_type) for credentials on the target side
- batch_precheck_resources: resolve source credential_type → target credential_type ID when building the step-4 lookup key
- CredentialImporter.import_resource: include credential_type in the GET credentials/ query so the correct same-name credential is matched



Partly addresses https://github.com/redhat-cop/aap-bridge/issues/66.