### PR TITLE
fix: correct resource scoping in batch precheck and handle duplicate credentials from AAP 2.4

### DIFF
--- a/src/aap_migration/cli/commands/export_import.py
+++ b/src/aap_migration/cli/commands/export_import.py
@@ -1470,8 +1470,15 @@ def import_cmd(
                 parent_field = PARENT_SCOPED_RESOURCES[resource_type]
                 name = resource_data.get("name")
                 source_parent_id = resource_data.get(parent_field)
+                # Schedules have a polymorphic parent: the concrete resource type is
+                # stored in _ujt_resource_type by ScheduleTransformer.  All other
+                # parent-scoped resources use the parent_field name as the resource type.
+                if parent_field == "unified_job_template":
+                    parent_resource_type = resource_data.get("_ujt_resource_type") or parent_field
+                else:
+                    parent_resource_type = parent_field
                 target_parent_id = (
-                    state.get_mapped_id(parent_field, source_parent_id)
+                    state.get_mapped_id(parent_resource_type, source_parent_id)
                     if source_parent_id is not None
                     else None
                 )

--- a/src/aap_migration/cli/commands/export_import.py
+++ b/src/aap_migration/cli/commands/export_import.py
@@ -1272,6 +1272,53 @@ def import_cmd(
             source_id_count=len(source_ids_for_reset),
         )
 
+        # Step 2 (credentials only): Credentials have no reliable composite unique key in
+        # AAP — the same name, organization, and credential_type can all be shared by
+        # multiple credentials.  Name-based target matching is therefore fundamentally
+        # unreliable.  Instead, restore IDMapping entries from MigrationProgress (which
+        # is never cleared) for credentials that were already imported in a previous run,
+        # and send everything else straight to the importer as a fresh CREATE.
+        if resource_type == "credentials":
+            to_import = []
+            found_count = 0
+            for resource in resources:
+                source_id = resource.get("_source_id")
+                name = resource.get("name")
+                if source_id is None:
+                    to_import.append(resource)
+                    continue
+                target_id = state.get_progress_target_id("credentials", source_id)
+                if target_id is not None:
+                    # Already imported in a previous run — restore the IDMapping row that
+                    # was cleared by reset_target_ids_for_source_ids above.
+                    state.save_id_mapping(
+                        resource_type="credentials",
+                        source_id=source_id,
+                        target_id=target_id,
+                        source_name=name,
+                        target_name=name,
+                    )
+                    found_count += 1
+                    logger.debug(
+                        "credential_mapping_restored_from_progress",
+                        source_id=source_id,
+                        target_id=target_id,
+                        name=name,
+                    )
+                else:
+                    to_import.append(resource)
+
+            if found_count > 0:
+                progress.update_phase(phase_id, 0, 0, found_count)
+                logger.info(
+                    "pre_existing_resources_found",
+                    resource_type=resource_type,
+                    already_existing=found_count,
+                    to_import=len(to_import),
+                    total=len(resources),
+                )
+            return to_import
+
         # Step 2: Get identifier field from importer
         identifier_field = getattr(importer, "IDENTIFIER_FIELD", "name")
 
@@ -1284,15 +1331,7 @@ def import_cmd(
             source_id = resource.get("_source_id")
             if identifier and source_id:
                 resource_identifiers.append(identifier)
-                # Credentials are unique by (name, organization, credential_type) in AAP,
-                # so two credentials can share a name if they have different types.
-                # Use a composite dict key to prevent same-name credentials from
-                # overwriting each other and being silently dropped.
-                if resource_type == "credentials":
-                    dict_key = (identifier, resource.get("credential_type"))
-                else:
-                    dict_key = identifier
-                resource_by_identifier[dict_key] = {"source_id": source_id, "data": resource}
+                resource_by_identifier[identifier] = {"source_id": source_id, "data": resource}
 
         if not resource_identifiers:
             logger.warning(
@@ -1358,16 +1397,7 @@ def import_cmd(
                 # Index by identifier for fast lookup
                 # For organization-scoped resources, use composite key (name, organization)
                 for existing_resource in existing_batch:
-                    if resource_type == "credentials":
-                        # Credentials are unique by (name, organization, credential_type).
-                        # Two credentials can share a name when they have different types.
-                        name = existing_resource.get("name")
-                        org = existing_resource.get("organization")
-                        cred_type = existing_resource.get("credential_type")
-                        if name is not None:
-                            key = (name, org, cred_type)
-                            existing_by_identifier[key] = existing_resource
-                    elif resource_type in ORGANIZATION_SCOPED_RESOURCES:
+                    if resource_type in ORGANIZATION_SCOPED_RESOURCES:
                         # Use (name, organization) as composite key
                         name = existing_resource.get("name")
                         org = existing_resource.get("organization")
@@ -1395,39 +1425,12 @@ def import_cmd(
         found_count = 0
         to_import = []
 
-        # Built-in AAP credential type IDs are stable across environments (same IDs in source
-        # and target).  Custom types (above this threshold) require an ID-mapping lookup.
-        _BUILTIN_CRED_TYPE_MAX_ID = 27
-
         for identifier, resource_info in resource_by_identifier.items():
             source_id = resource_info["source_id"]
             resource_data = resource_info["data"]
 
-            # Derive the plain resource name regardless of whether identifier is a
-            # simple string (most resource types) or a composite tuple (credentials).
-            resource_name = resource_data.get("name") or (
-                identifier[0] if isinstance(identifier, tuple) else identifier
-            )
-
             # Build lookup key based on resource scope
-            if resource_type == "credentials":
-                # Credentials are unique by (name, organization, credential_type).
-                # Resolve the source credential_type ID to the target ID so the lookup
-                # key matches what was indexed from the target API response.
-                name = resource_data.get("name")
-                org = resource_data.get("organization")
-                source_cred_type_id = resource_data.get("credential_type")
-                if source_cred_type_id is not None:
-                    target_cred_type_id = state.get_mapped_id(
-                        "credential_types", source_cred_type_id
-                    )
-                    if target_cred_type_id is None and source_cred_type_id <= _BUILTIN_CRED_TYPE_MAX_ID:
-                        # Built-in types keep the same ID across environments.
-                        target_cred_type_id = source_cred_type_id
-                else:
-                    target_cred_type_id = None
-                lookup_key = (name, org, target_cred_type_id)
-            elif resource_type in ORGANIZATION_SCOPED_RESOURCES:
+            if resource_type in ORGANIZATION_SCOPED_RESOURCES:
                 # For org-scoped resources, use (name, organization) as key
                 name = resource_data.get("name")
                 org = resource_data.get("organization")
@@ -1454,7 +1457,7 @@ def import_cmd(
                     resource_type=mapping_resource_type,
                     source_id=source_id,
                     target_id=existing["id"],
-                    source_name=resource_name,
+                    source_name=identifier,
                     target_name=existing.get(identifier_field),
                 )
 

--- a/src/aap_migration/cli/commands/export_import.py
+++ b/src/aap_migration/cli/commands/export_import.py
@@ -40,6 +40,7 @@ from aap_migration.migration.state import ExportRunContext, MigrationState
 from aap_migration.reporting.live_progress import MigrationProgressDisplay
 from aap_migration.resources import (
     ORGANIZATION_SCOPED_RESOURCES,
+    PARENT_SCOPED_RESOURCES,
     RESOURCE_REGISTRY,
     ResourceCategory,
     get_endpoint,
@@ -1331,12 +1332,15 @@ def import_cmd(
             source_id = resource.get("_source_id")
             if identifier and source_id:
                 resource_identifiers.append(identifier)
-                # For org-scoped resources, two resources can share the same name as
-                # long as they belong to different organizations.  Key the dict on
-                # (name, source_org_id) so same-name resources in different orgs don't
-                # overwrite each other and get silently dropped.
+                # Resources that share a name across different parent scopes must use
+                # a composite key so same-name entries don't overwrite each other.
                 if resource_type in ORGANIZATION_SCOPED_RESOURCES:
+                    # Unique per (name, organization)
                     dict_key = (identifier, resource.get("organization"))
+                elif resource_type in PARENT_SCOPED_RESOURCES:
+                    # Unique per (name, parent) e.g. inventory_sources per inventory
+                    parent_field = PARENT_SCOPED_RESOURCES[resource_type]
+                    dict_key = (identifier, resource.get(parent_field))
                 else:
                     dict_key = identifier
                 resource_by_identifier[dict_key] = {"source_id": source_id, "data": resource}
@@ -1402,19 +1406,27 @@ def import_cmd(
                     resource_type=resource_type, filters=filters
                 )
 
-                # Index by identifier for fast lookup
-                # For organization-scoped resources, use composite key (name, organization)
+                # Index by identifier for fast lookup using the same scoping rules as
+                # resource_by_identifier (but with target-side IDs from the API response).
                 for existing_resource in existing_batch:
                     if resource_type in ORGANIZATION_SCOPED_RESOURCES:
-                        # Use (name, organization) as composite key
+                        # Unique per (name, organization)
                         name = existing_resource.get("name")
                         org = existing_resource.get("organization")
                         if name is not None:
                             # Handle null organization (some credentials can have null org)
                             key = (name, org) if org is not None else name
                             existing_by_identifier[key] = existing_resource
+                    elif resource_type in PARENT_SCOPED_RESOURCES:
+                        # Unique per (name, parent) e.g. inventory_sources per inventory
+                        parent_field = PARENT_SCOPED_RESOURCES[resource_type]
+                        name = existing_resource.get("name")
+                        parent_id = existing_resource.get(parent_field)
+                        if name is not None:
+                            key = (name, parent_id) if parent_id is not None else name
+                            existing_by_identifier[key] = existing_resource
                     else:
-                        # Use name only for globally unique resources
+                        # Globally unique resources — key by name/username/hostname
                         existing_identifier = existing_resource.get(identifier_field)
                         if existing_identifier:
                             existing_by_identifier[existing_identifier] = existing_resource
@@ -1443,20 +1455,31 @@ def import_cmd(
                 identifier[0] if isinstance(identifier, tuple) else identifier
             )
 
-            # Build lookup key based on resource scope
+            # Build lookup key based on resource scope.  Source-side IDs must be
+            # resolved to target-side IDs so the key matches existing_by_identifier.
             if resource_type in ORGANIZATION_SCOPED_RESOURCES:
-                # existing_by_identifier is keyed by (name, target_org_id).  The source
-                # data carries the source-side org ID, so we must resolve it to the
-                # target-side ID before the lookup; otherwise the keys will never match.
                 name = resource_data.get("name")
                 source_org_id = resource_data.get("organization")
-                if source_org_id is not None:
-                    target_org_id = state.get_mapped_id("organizations", source_org_id)
-                else:
-                    target_org_id = None
+                target_org_id = (
+                    state.get_mapped_id("organizations", source_org_id)
+                    if source_org_id is not None
+                    else None
+                )
                 lookup_key = (name, target_org_id) if target_org_id is not None else name
+            elif resource_type in PARENT_SCOPED_RESOURCES:
+                parent_field = PARENT_SCOPED_RESOURCES[resource_type]
+                name = resource_data.get("name")
+                source_parent_id = resource_data.get(parent_field)
+                target_parent_id = (
+                    state.get_mapped_id(parent_field, source_parent_id)
+                    if source_parent_id is not None
+                    else None
+                )
+                lookup_key = (
+                    (name, target_parent_id) if target_parent_id is not None else name
+                )
             else:
-                # For globally unique resources, use identifier (name/username/etc.)
+                # Globally unique resources — identifier is the plain name/username/etc.
                 lookup_key = identifier
 
             # Debug: Log lookup key being used

--- a/src/aap_migration/cli/commands/export_import.py
+++ b/src/aap_migration/cli/commands/export_import.py
@@ -1331,7 +1331,15 @@ def import_cmd(
             source_id = resource.get("_source_id")
             if identifier and source_id:
                 resource_identifiers.append(identifier)
-                resource_by_identifier[identifier] = {"source_id": source_id, "data": resource}
+                # For org-scoped resources, two resources can share the same name as
+                # long as they belong to different organizations.  Key the dict on
+                # (name, source_org_id) so same-name resources in different orgs don't
+                # overwrite each other and get silently dropped.
+                if resource_type in ORGANIZATION_SCOPED_RESOURCES:
+                    dict_key = (identifier, resource.get("organization"))
+                else:
+                    dict_key = identifier
+                resource_by_identifier[dict_key] = {"source_id": source_id, "data": resource}
 
         if not resource_identifiers:
             logger.warning(
@@ -1429,15 +1437,26 @@ def import_cmd(
             source_id = resource_info["source_id"]
             resource_data = resource_info["data"]
 
+            # Derive the plain resource name regardless of whether the dict key is a
+            # simple string (globally unique resources) or a (name, org_id) tuple.
+            resource_name = resource_data.get(identifier_field) or (
+                identifier[0] if isinstance(identifier, tuple) else identifier
+            )
+
             # Build lookup key based on resource scope
             if resource_type in ORGANIZATION_SCOPED_RESOURCES:
-                # For org-scoped resources, use (name, organization) as key
+                # existing_by_identifier is keyed by (name, target_org_id).  The source
+                # data carries the source-side org ID, so we must resolve it to the
+                # target-side ID before the lookup; otherwise the keys will never match.
                 name = resource_data.get("name")
-                org = resource_data.get("organization")
-                # Handle null organization (some credentials can have null org)
-                lookup_key = (name, org) if org is not None else name
+                source_org_id = resource_data.get("organization")
+                if source_org_id is not None:
+                    target_org_id = state.get_mapped_id("organizations", source_org_id)
+                else:
+                    target_org_id = None
+                lookup_key = (name, target_org_id) if target_org_id is not None else name
             else:
-                # For globally unique resources, use identifier (name)
+                # For globally unique resources, use identifier (name/username/etc.)
                 lookup_key = identifier
 
             # Debug: Log lookup key being used
@@ -1457,7 +1476,7 @@ def import_cmd(
                     resource_type=mapping_resource_type,
                     source_id=source_id,
                     target_id=existing["id"],
-                    source_name=identifier,
+                    source_name=resource_name,
                     target_name=existing.get(identifier_field),
                 )
 

--- a/src/aap_migration/migration/importer.py
+++ b/src/aap_migration/migration/importer.py
@@ -3232,116 +3232,34 @@ class CredentialImporter(ResourceImporter):
         data.pop("_needs_vault_lookup", None)
 
         try:
-            # Find existing credential in target by name AND credential_type.
-            # AAP allows multiple credentials with the same name when they have
-            # different credential types, so we must filter by type to avoid
-            # mapping this credential to the wrong same-name credential.
-            query_params: dict[str, Any] = {"name": name}
-            source_cred_type_id = data.get("credential_type")
-            if source_cred_type_id:
-                target_cred_type_id = self.state.get_mapped_id(
-                    "credential_types", source_cred_type_id
-                )
-                if target_cred_type_id is None and source_cred_type_id <= self.BUILTIN_CREDENTIAL_TYPE_MAX_ID:
-                    # Built-in types keep the same ID across environments.
-                    target_cred_type_id = source_cred_type_id
-                if target_cred_type_id is not None:
-                    query_params["credential_type"] = target_cred_type_id
+            # AAP permits credentials with identical (name, organization, credential_type),
+            # so there is no reliable composite key to match a source credential against an
+            # existing target credential.  Always CREATE a new credential; idempotency on
+            # re-runs is handled by the is_migrated() check above (MigrationProgress) and
+            # by batch_precheck_resources restoring IDMapping from MigrationProgress.
+            logger.info(
+                "credential_creating",
+                name=name,
+                source_id=source_id,
+            )
 
-            results = await self.client.get("credentials/", params=query_params)
-            resources = results.get("results", [])
+            # Resolve dependencies
+            if resolve_dependencies:
+                data = await self._resolve_dependencies(resource_type, data)
 
-            if resources:
-                # Credential exists - PATCH it
-                target_id = resources[0]["id"]
-                is_managed = resources[0].get("managed", False)
+            result = await self.client.create_resource(
+                resource_type="credentials",
+                data=data,
+                check_exists=False,
+            )
 
-                # Skip PATCH for managed (built-in) credentials - AAP doesn't allow modifications
-                if is_managed:
-                    logger.info(
-                        "credential_managed_skip_patch",
-                        name=name,
-                        source_id=source_id,
-                        target_id=target_id,
-                        message="Skipping PATCH for managed credential - saving mapping only",
-                    )
-                    # Save mapping without patching
-                    self.state.save_id_mapping(
-                        resource_type=resource_type,
-                        source_id=source_id,
-                        target_id=target_id,
-                        source_name=name,
-                        target_name=name,
-                    )
-                    self.state.mark_completed(
-                        resource_type=resource_type,
-                        source_id=source_id,
-                        target_id=target_id,
-                        target_name=name,
-                    )
-                    self.stats["skipped_count"] += 1
-                    # Return skipped signal
-                    return {"id": target_id, "name": name, "_skipped": True}
-
-                # Resolve dependencies
-                if resolve_dependencies:
-                    data = await self._resolve_dependencies(resource_type, data)
-
-                # Build PATCH payload (organization, description only)
-                patch_data = {}
-                if data.get("organization"):
-                    patch_data["organization"] = data["organization"]
-                if data.get("description"):
-                    patch_data["description"] = data["description"]
-
-                # PATCH the credential
-                if patch_data:
-                    await self.client.update_resource("credentials", target_id, patch_data)
-                    logger.info(
-                        "credential_patched",
-                        name=name,
-                        source_id=source_id,
-                        target_id=target_id,
-                        patched_fields=list(patch_data.keys()),
-                    )
-                else:
-                    logger.info(
-                        "credential_mapped_no_patch",
-                        name=name,
-                        source_id=source_id,
-                        target_id=target_id,
-                        message="No fields to patch - mapping only",
-                    )
-
-                result = {"id": target_id, "name": name, "_patched": bool(patch_data)}
-
-            else:
-                # Credential does not exist - CREATE it
-                logger.info(
-                    "credential_creating",
-                    name=name,
-                    source_id=source_id,
-                    message="Creating new credential with temporary values",
-                )
-
-                # Resolve dependencies
-                if resolve_dependencies:
-                    data = await self._resolve_dependencies(resource_type, data)
-
-                # Create resource
-                result = await self.client.create_resource(
-                    resource_type="credentials",
-                    data=data,
-                    check_exists=False,  # We already checked
-                )
-
-                target_id = result["id"]
-                logger.info(
-                    "credential_created",
-                    name=name,
-                    source_id=source_id,
-                    target_id=target_id,
-                )
+            target_id = result["id"]
+            logger.info(
+                "credential_created",
+                name=name,
+                source_id=source_id,
+                target_id=target_id,
+            )
 
             # Save mapping
             self.state.save_id_mapping(

--- a/src/aap_migration/migration/importer.py
+++ b/src/aap_migration/migration/importer.py
@@ -3231,16 +3231,18 @@ class CredentialImporter(ResourceImporter):
         data.pop("_encrypted_fields", None)
         data.pop("_needs_vault_lookup", None)
 
+        original_name = name  # preserved for save_id_mapping if a rename occurs
         try:
             # AAP 2.6 enforces a unique constraint on (organization_id, name,
             # credential_type_id) at the database level, even though AAP 2.4 on the
             # source did not always do so.  There is therefore no reliable composite key
             # to match a source credential to an existing target credential before
             # attempting the CREATE.  Always try to CREATE; if the target rejects it
-            # with a 400 "duplicate key" error we fall back to finding the already-
-            # existing credential and mapping to it.  Idempotency on re-runs is handled
-            # by the is_migrated() check above (MigrationProgress) and by
-            # batch_precheck_resources restoring IDMapping from MigrationProgress.
+            # with a 400 "duplicate key" error we rename the credential so that every
+            # source credential gets its own distinct target credential, which preserves
+            # correct dependency resolution for downstream objects.  Idempotency on
+            # re-runs is handled by the is_migrated() check above (MigrationProgress)
+            # and by batch_precheck_resources restoring IDMapping from MigrationProgress.
             logger.info(
                 "credential_creating",
                 name=name,
@@ -3266,46 +3268,68 @@ class CredentialImporter(ResourceImporter):
                     target_id=target_id,
                 )
             except APIError as create_err:
-                # AAP 2.6 returns 400 when (org, name, credential_type) already exists.
-                # The source (2.4) may have had multiple credentials with the same
-                # composite key; on the target we can only map them all to the one
-                # existing credential.
+                # AAP 2.6 enforces a unique (org, name, credential_type) constraint that
+                # the source AAP 2.4 did not always enforce.  When two source credentials
+                # share an identical composite key, rename the duplicate so that every
+                # source credential maps to its own distinct target credential.  This
+                # preserves correct dependency resolution for any job templates, projects,
+                # etc. that referenced the duplicate source credential.
+                #
+                # Naming convention: "<original name> [src:<source_id>]"
+                # The source ID is appended to the description as well so the rename
+                # is self-documenting on the target.
                 err_str = str(create_err).lower()
                 if create_err.status_code == 400 and (
                     "duplicate key" in err_str  # PostgreSQL DB-level error
                     or "already exists" in err_str  # Django validation-level error
                 ):
-                    params: dict[str, Any] = {"name": name}
-                    if data.get("credential_type"):
-                        params["credential_type"] = data["credential_type"]
-                    if data.get("organization"):
-                        params["organization"] = data["organization"]
-                    lookup = await self.client.get("credentials/", params=params)
-                    existing = lookup.get("results", [])
-                    if existing:
-                        target_id = existing[0]["id"]
-                        logger.warning(
-                            "credential_duplicate_mapped_to_existing",
-                            name=name,
-                            source_id=source_id,
-                            target_id=target_id,
-                            message=(
-                                "Source had duplicate credentials with the same "
-                                "(name, org, type); mapped to the single target credential"
-                            ),
-                        )
-                        result = {"id": target_id, "name": name, "_duplicate": True}
-                    else:
-                        raise
+                    original_name = name
+                    renamed = f"{original_name} [src:{source_id}]"
+                    original_description = data.get("description") or ""
+                    rename_note = (
+                        f"Renamed from '{original_name}' during migration: source "
+                        f"environment had a duplicate credential with the same name, "
+                        f"organization, and type (source id: {source_id})."
+                    )
+                    data["name"] = renamed
+                    data["description"] = (
+                        f"{original_description}\n{rename_note}".strip()
+                    )
+                    logger.warning(
+                        "credential_duplicate_renamed",
+                        original_name=original_name,
+                        renamed_to=renamed,
+                        source_id=source_id,
+                        message=(
+                            "Source had a duplicate credential with the same "
+                            "(name, org, type); renamed on target to preserve "
+                            "distinct mapping for dependency resolution"
+                        ),
+                    )
+                    result = await self.client.create_resource(
+                        resource_type="credentials",
+                        data=data,
+                        check_exists=False,
+                    )
+                    target_id = result["id"]
+                    name = renamed  # keep target_name in sync for mapping below
+                    logger.info(
+                        "credential_created_with_rename",
+                        original_name=original_name,
+                        renamed_to=renamed,
+                        source_id=source_id,
+                        target_id=target_id,
+                    )
                 else:
                     raise
 
-            # Save mapping
+            # Save mapping (source_name is the original pre-rename name; target_name
+            # reflects whatever name the credential actually has on the target).
             self.state.save_id_mapping(
                 resource_type=resource_type,
                 source_id=source_id,
                 target_id=target_id,
-                source_name=name,
+                source_name=original_name,
                 target_name=name,
             )
             self.state.mark_completed(

--- a/src/aap_migration/migration/importer.py
+++ b/src/aap_migration/migration/importer.py
@@ -3232,34 +3232,71 @@ class CredentialImporter(ResourceImporter):
         data.pop("_needs_vault_lookup", None)
 
         try:
-            # AAP permits credentials with identical (name, organization, credential_type),
-            # so there is no reliable composite key to match a source credential against an
-            # existing target credential.  Always CREATE a new credential; idempotency on
-            # re-runs is handled by the is_migrated() check above (MigrationProgress) and
-            # by batch_precheck_resources restoring IDMapping from MigrationProgress.
+            # AAP 2.6 enforces a unique constraint on (organization_id, name,
+            # credential_type_id) at the database level, even though AAP 2.4 on the
+            # source did not always do so.  There is therefore no reliable composite key
+            # to match a source credential to an existing target credential before
+            # attempting the CREATE.  Always try to CREATE; if the target rejects it
+            # with a 400 "duplicate key" error we fall back to finding the already-
+            # existing credential and mapping to it.  Idempotency on re-runs is handled
+            # by the is_migrated() check above (MigrationProgress) and by
+            # batch_precheck_resources restoring IDMapping from MigrationProgress.
             logger.info(
                 "credential_creating",
                 name=name,
                 source_id=source_id,
             )
 
-            # Resolve dependencies
+            # Resolve dependencies first so we have the target-side IDs for any
+            # duplicate-key fallback query below.
             if resolve_dependencies:
                 data = await self._resolve_dependencies(resource_type, data)
 
-            result = await self.client.create_resource(
-                resource_type="credentials",
-                data=data,
-                check_exists=False,
-            )
-
-            target_id = result["id"]
-            logger.info(
-                "credential_created",
-                name=name,
-                source_id=source_id,
-                target_id=target_id,
-            )
+            try:
+                result = await self.client.create_resource(
+                    resource_type="credentials",
+                    data=data,
+                    check_exists=False,
+                )
+                target_id = result["id"]
+                logger.info(
+                    "credential_created",
+                    name=name,
+                    source_id=source_id,
+                    target_id=target_id,
+                )
+            except APIError as create_err:
+                # AAP 2.6 returns 400 when (org, name, credential_type) already exists.
+                # The source (2.4) may have had multiple credentials with the same
+                # composite key; on the target we can only map them all to the one
+                # existing credential.
+                if create_err.status_code == 400 and "duplicate key" in str(
+                    create_err
+                ).lower():
+                    params: dict[str, Any] = {"name": name}
+                    if data.get("credential_type"):
+                        params["credential_type"] = data["credential_type"]
+                    if data.get("organization"):
+                        params["organization"] = data["organization"]
+                    lookup = await self.client.get("credentials/", params=params)
+                    existing = lookup.get("results", [])
+                    if existing:
+                        target_id = existing[0]["id"]
+                        logger.warning(
+                            "credential_duplicate_mapped_to_existing",
+                            name=name,
+                            source_id=source_id,
+                            target_id=target_id,
+                            message=(
+                                "Source had duplicate credentials with the same "
+                                "(name, org, type); mapped to the single target credential"
+                            ),
+                        )
+                        result = {"id": target_id, "name": name, "_duplicate": True}
+                    else:
+                        raise
+                else:
+                    raise
 
             # Save mapping
             self.state.save_id_mapping(

--- a/src/aap_migration/migration/importer.py
+++ b/src/aap_migration/migration/importer.py
@@ -3270,9 +3270,11 @@ class CredentialImporter(ResourceImporter):
                 # The source (2.4) may have had multiple credentials with the same
                 # composite key; on the target we can only map them all to the one
                 # existing credential.
-                if create_err.status_code == 400 and "duplicate key" in str(
-                    create_err
-                ).lower():
+                err_str = str(create_err).lower()
+                if create_err.status_code == 400 and (
+                    "duplicate key" in err_str  # PostgreSQL DB-level error
+                    or "already exists" in err_str  # Django validation-level error
+                ):
                     params: dict[str, Any] = {"name": name}
                     if data.get("credential_type"):
                         params["credential_type"] = data["credential_type"]

--- a/src/aap_migration/migration/state.py
+++ b/src/aap_migration/migration/state.py
@@ -971,6 +971,48 @@ class MigrationState:
                 )
                 raise StateError(f"Failed to get mapped ID: {e}") from e
 
+    def get_progress_target_id(
+        self,
+        resource_type: str,
+        source_id: int,
+    ) -> int | None:
+        """Get the target ID stored in MigrationProgress for a source resource.
+
+        Unlike get_mapped_id() which reads IDMapping (reset between runs), this
+        reads MigrationProgress which is never cleared, making it safe to call
+        after reset_target_ids_for_source_ids() has nulled out IDMapping rows.
+
+        Args:
+            resource_type: Type of resource
+            source_id: Source system resource ID
+
+        Returns:
+            Target ID recorded when the resource was last completed, or None
+        """
+        resource_type = self._normalize(resource_type)
+        with self._lock:
+            try:
+                with get_session(self.database_url) as session:
+                    progress = (
+                        session.query(MigrationProgress)
+                        .filter_by(
+                            resource_type=resource_type,
+                            source_id=source_id,
+                            status="completed",
+                        )
+                        .first()
+                    )
+                    return progress.target_id if progress else None
+
+            except Exception as e:
+                logger.error(
+                    "failed_to_get_progress_target_id",
+                    resource_type=resource_type,
+                    source_id=source_id,
+                    error=str(e),
+                )
+                raise StateError(f"Failed to get progress target ID: {e}") from e
+
     def get_mapped_id_by_name(
         self,
         resource_type: str,

--- a/src/aap_migration/resources.py
+++ b/src/aap_migration/resources.py
@@ -566,15 +566,21 @@ ORGANIZATION_SCOPED_RESOURCES = {
     "credentials",
     "job_templates",
     "workflow_job_templates",
+    "notification_templates",
     "teams",
 }
 
 # Parent-scoped resources: unique within parent resource
 # Format: {resource_type: parent_field_name}
+#
+# Note: schedules use a polymorphic parent (unified_job_template) whose concrete
+# resource type is stored in the _ujt_resource_type field added by ScheduleTransformer.
+# The precheck resolves it via that field rather than a fixed resource type name.
 PARENT_SCOPED_RESOURCES = {
     "hosts": "inventory",
     "groups": "inventory",
     "inventory_sources": "inventory",
+    "schedules": "unified_job_template",
 }
 
 


### PR DESCRIPTION
## Summary

AAP allows multiple resources to share the same name as long as they are in
different organizations or parent resources. The batch precheck (`batch_precheck_resources`)
was keying source and target resources by name alone, which caused same-name
resources in different scopes to silently overwrite each other — one would be
dropped before it ever reached the importer. Additionally, AAP 2.6 enforces
a unique DB constraint on credentials that AAP 2.4 did not always enforce,
causing import failures when the source had duplicate credentials.

## Changes

### Credential import (`importer.py`, `state.py`)
- Credentials have no reliable composite unique key in AAP (name, org, and
  type can all be shared). Removed name-based precheck matching for credentials
  entirely; the precheck now restores `IDMapping` entries from `MigrationProgress`
  (which is never cleared) for already-imported credentials, preserving
  dependency resolution on re-runs without guessing at target matches.
- `CredentialImporter.import_resource` now always CREATEs rather than
  GET-by-name + PATCH. Idempotency on re-runs is handled by the `is_migrated()`
  check at the top of the method.
- When the target rejects a CREATE with a 400 "duplicate key" or "already exists"
  error (AAP 2.4 source had credentials with identical name/org/type that 2.6
  won't allow), the credential is **renamed** to `"<name> [src:<source_id>]"`
  and the CREATE is retried. This gives every source credential its own distinct
  target credential, preserving correct dependency resolution for job templates
  and other objects that referenced the duplicate. A warning is logged and the
  rename reason is written into the credential description.
- Added `MigrationState.get_progress_target_id()` to read `target_id` from
  `MigrationProgress` rather than `IDMapping`, which is safe to call after
  `reset_target_ids_for_source_ids()` has cleared `IDMapping` rows.

### Batch precheck scoping (`export_import.py`, `resources.py`)
All three steps of `batch_precheck_resources` now consistently use composite
keys that match the actual uniqueness scope of each resource type:

| Scope | Key | Resource types |
|---|---|---|
| Org-scoped | `(name, target_org_id)` | projects, inventories, job_templates, workflow_job_templates, notification_templates, teams |
| Parent-scoped | `(name, target_parent_id)` | inventory_sources, hosts, groups, schedules |
| Globally unique | `name` / `username` / `hostname` | organizations, users, instances |

Previously:
- `resource_by_identifier` used name only → same-name resources in different scopes overwrote each other
- `existing_by_identifier` used source-side org/parent IDs for org/parent-scoped resources, but the target API returns target-side IDs → lookups never matched, so the precheck never correctly identified pre-existing resources

Fixed by:
- Keying `resource_by_identifier` on `(name, source_scope_id)` for scoped types
- Resolving source scope IDs to target scope IDs via `state.get_mapped_id()` before building the step-4 lookup key
- Added `notification_templates` to `ORGANIZATION_SCOPED_RESOURCES`
- Added `schedules` to `PARENT_SCOPED_RESOURCES` with parent field `unified_job_template`; because that parent is polymorphic, the precheck uses `_ujt_resource_type` (set by `ScheduleTransformer`) to resolve the correct resource type for ID mapping

Resolves: https://github.com/redhat-cop/aap-bridge/issues/66.