### PR TITLE
feat(credentials): skip installer-created default credentials from mi…

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -224,6 +224,12 @@ export:
     - Hub Default execution environment
     - Hub Minimal execution environment
     - Minimal execution environment
+  # Omit these installer-created credential names from export/import (case-insensitive).
+  # The AAP installer recreates them automatically in the target environment.
+  # Use [] to migrate all credentials.
+  skip_credential_names:
+    - Ansible Galaxy
+    - Default Execution Environment Registry Credential
   skip_pending_deletion_inventories: true
   skip_hosts_with_inventory_sources: false
   records_per_file: 1000

--- a/docs/user-guide/filtering-and-skipping.md
+++ b/docs/user-guide/filtering-and-skipping.md
@@ -6,7 +6,7 @@ This document explains why resource counts in the target environment may be lowe
 
 Resources can be filtered or skipped for several reasons:
 
-- **Intentional exclusion**: Dynamic hosts, smart inventories, and disabled schedules are excluded by design
+- **Intentional exclusion**: Dynamic hosts, smart inventories, installer-created default credentials, and disabled schedules are excluded by design
 - **Dependency validation**: Resources with missing dependencies cannot be migrated
 - **Idempotency**: Already-migrated resources are skipped to prevent duplicates
 - **System constraints**: Some resources are read-only or non-deletable
@@ -27,6 +27,7 @@ These filters are controlled via `config.yaml` under the `export:` section:
 | `skip_smart_inventories` | `true` | Inventories | Excludes smart inventories (computed inventories). Only static inventories are exported. |
 | `skip_pending_deletion_inventories` | `true` | Inventories | Excludes inventories marked for deletion in the source. |
 | `skip_hosts_with_inventory_sources` | `true` | Hosts | Same as `skip_dynamic_hosts` - excludes hosts with `has_inventory_sources=true`. |
+| `skip_credential_names` | `["Ansible Galaxy", "Default Execution Environment Registry Credential"]` | Credentials | Excludes installer-created default credentials by name (case-insensitive). The target installer recreates these automatically. Use `[]` to migrate all credentials. |
 
 **Example configuration:**
 
@@ -35,6 +36,10 @@ export:
   skip_dynamic_hosts: true
   skip_smart_inventories: true
   skip_pending_deletion_inventories: true
+  # Remove entries or use [] to migrate these credentials
+  skip_credential_names:
+    - Ansible Galaxy
+    - Default Execution Environment Registry Credential
 ```
 
 ### Built-in Filters (Not Configurable)
@@ -137,6 +142,7 @@ The cleanup command excludes certain resources that cannot be deleted.
 |-------|--------|---------------|-----------------|
 | Export | Dynamic hosts (inventory source managed) | Yes | Check `skip_dynamic_hosts` setting |
 | Export | Smart/pending deletion inventories | Yes | Check `skip_smart_inventories` setting |
+| Export | Installer-created default credentials | Yes | Check `skip_credential_names` setting |
 | Export | Disabled schedules | No | Only enabled schedules are exported |
 | Transform | Missing organization | No | Check export logs for organization |
 | Transform | Missing credential type | No | Ensure credential types exported first |
@@ -158,7 +164,7 @@ When comparing source and target counts, consider:
 1. **Hosts**: If `skip_dynamic_hosts=true` (default), dynamic hosts won't be counted
 2. **Inventories**: Smart inventories and pending deletion inventories are excluded
 3. **Schedules**: Disabled schedules are not exported
-4. **Credentials**: Some may be skipped due to unmapped external types
+4. **Credentials**: Installer-created defaults (`Ansible Galaxy`, `Default Execution Environment Registry Credential`) are skipped by default; others may be skipped due to unmapped external types
 
 ### Investigating Discrepancies
 
@@ -201,6 +207,9 @@ export:
 
   # Include inventories pending deletion
   skip_pending_deletion_inventories: false
+
+  # Include installer-created default credentials (normally recreated by the target installer)
+  skip_credential_names: []
 ```
 
 !!! warning "Changing Defaults"

--- a/src/aap_migration/cli/commands/cleanup.py
+++ b/src/aap_migration/cli/commands/cleanup.py
@@ -26,7 +26,11 @@ from aap_migration.cli.utils import (
 from aap_migration.client.aap_target_client import AAPTargetClient
 from aap_migration.client.bulk_operations import BulkOperations
 from aap_migration.client.exceptions import APIError, NotFoundError, PendingDeletionError, ResourceInUseError
-from aap_migration.config import MigrationConfig, normalized_execution_environment_skip_names
+from aap_migration.config import (
+    MigrationConfig,
+    normalized_credential_skip_names,
+    normalized_execution_environment_skip_names,
+)
 from aap_migration.migration.database import get_session
 from aap_migration.migration.models import IDMapping, MigrationProgress
 from aap_migration.reporting.live_progress import MigrationProgressDisplay
@@ -1147,6 +1151,9 @@ async def delete_resources(
         ee_skip_names = normalized_execution_environment_skip_names(
             config.export.skip_execution_environment_names
         )
+        cred_skip_names = normalized_credential_skip_names(
+            config.export.skip_credential_names
+        )
 
         # Filter resources to determine what to skip vs delete
         resources_to_delete = []
@@ -1174,6 +1181,14 @@ async def delete_resources(
                 if not skip_resource and is_managed:
                     skip_resource = True
                     skip_reason = "managed execution environment"
+
+            # Credentials: always respect the skip-name list regardless of --full / skip_default.
+            # These are installer-created defaults that should not be deleted from the target.
+            if resource_type == "credentials" and cred_skip_names:
+                rn = resource.get("name")
+                if rn and isinstance(rn, str) and rn.strip().casefold() in cred_skip_names:
+                    skip_resource = True
+                    skip_reason = "export.skip_credential_names"
 
             if skip_default:
                 # Skip Default organization (by name or by ID=1)

--- a/src/aap_migration/cli/commands/export_import.py
+++ b/src/aap_migration/cli/commands/export_import.py
@@ -460,6 +460,7 @@ def export(
                         ctx.migration_state,
                         ctx.config.performance,
                         skip_execution_environment_names=ctx.config.export.skip_execution_environment_names,
+                        skip_credential_names=ctx.config.export.skip_credential_names,
                     )
                 except NotImplementedError as e:
                     # Exporter not implemented yet
@@ -595,6 +596,7 @@ def export(
                             ctx.migration_state,
                             ctx.config.performance,
                             skip_execution_environment_names=ctx.config.export.skip_execution_environment_names,
+                            skip_credential_names=ctx.config.export.skip_credential_names,
                         )
 
                         # Apply skip_dynamic_hosts filter for hosts
@@ -1728,6 +1730,7 @@ def import_cmd(
                                 ctx.config.performance,
                                 ctx.config.resource_mappings,
                                 skip_execution_environment_names=ctx.config.export.skip_execution_environment_names,
+                                skip_credential_names=ctx.config.export.skip_credential_names,
                             )
                         except NotImplementedError:
                             logger.info(
@@ -1910,6 +1913,7 @@ def import_cmd(
                                         ctx.config.performance,
                                         ctx.config.resource_mappings,
                                         skip_execution_environment_names=ctx.config.export.skip_execution_environment_names,
+                                        skip_credential_names=ctx.config.export.skip_credential_names,
                                     )
                                     if hasattr(user_importer, "sync_team_memberships_for_existing_users"):
                                         await user_importer.sync_team_memberships_for_existing_users(
@@ -2120,6 +2124,7 @@ def import_cmd(
                             ctx.config.performance,
                             ctx.config.resource_mappings,
                             skip_execution_environment_names=ctx.config.export.skip_execution_environment_names,
+                            skip_credential_names=ctx.config.export.skip_credential_names,
                         )
                         n = await user_importer.sync_user_resource_role_grants_from_xformed(
                             input_dir
@@ -2138,6 +2143,7 @@ def import_cmd(
                             ctx.config.performance,
                             ctx.config.resource_mappings,
                             skip_execution_environment_names=ctx.config.export.skip_execution_environment_names,
+                            skip_credential_names=ctx.config.export.skip_credential_names,
                         )
                         n = await team_importer.sync_team_resource_role_grants_from_xformed(
                             input_dir

--- a/src/aap_migration/config.py
+++ b/src/aap_migration/config.py
@@ -578,6 +578,21 @@ def normalized_execution_environment_skip_names(names: list[str] | None) -> froz
     return frozenset(s.strip().casefold() for s in names if s and str(s).strip())
 
 
+# Default credential names created by the AAP installer that should not be migrated
+# because the installer in the target environment recreates them automatically.
+DEFAULT_SKIP_CREDENTIAL_NAMES: tuple[str, ...] = (
+    "Ansible Galaxy",
+    "Default Execution Environment Registry Credential",
+)
+
+
+def normalized_credential_skip_names(names: list[str] | None) -> frozenset[str]:
+    """Normalize credential display names for case-insensitive matching."""
+    if not names:
+        return frozenset()
+    return frozenset(s.strip().casefold() for s in names if s and str(s).strip())
+
+
 class ExportConfig(BaseModel):
     """Export configuration options."""
 
@@ -625,6 +640,14 @@ class ExportConfig(BaseModel):
         description=(
             "Execution environment `name` values to omit from export and import "
             "(case-insensitive). Edit this list in config; use [] to include all EEs."
+        ),
+    )
+    skip_credential_names: list[str] = Field(
+        default_factory=lambda: list(DEFAULT_SKIP_CREDENTIAL_NAMES),
+        description=(
+            "Credential `name` values to omit from export and import "
+            "(case-insensitive). These are installer-created defaults that are "
+            "recreated automatically in the target environment. Use [] to migrate all."
         ),
     )
     records_per_file: int = Field(

--- a/src/aap_migration/migration/coordinator.py
+++ b/src/aap_migration/migration/coordinator.py
@@ -476,6 +476,7 @@ class MigrationCoordinator:
                 state=self.state,
                 performance_config=self.config.performance,
                 skip_execution_environment_names=self.config.export.skip_execution_environment_names,
+                skip_credential_names=self.config.export.skip_credential_names,
             )
 
             transformer = create_transformer(
@@ -491,6 +492,7 @@ class MigrationCoordinator:
                 performance_config=self.config.performance,
                 resource_mappings=self.config.resource_mappings,
                 skip_execution_environment_names=self.config.export.skip_execution_environment_names,
+                skip_credential_names=self.config.export.skip_credential_names,
             )
 
             # Special handling for hosts (bulk operations)

--- a/src/aap_migration/migration/exporter.py
+++ b/src/aap_migration/migration/exporter.py
@@ -12,7 +12,11 @@ from typing import Any, Protocol, runtime_checkable
 
 from aap_migration.client.aap_source_client import AAPSourceClient
 from aap_migration.client.exceptions import APIError
-from aap_migration.config import PerformanceConfig, normalized_execution_environment_skip_names
+from aap_migration.config import (
+    PerformanceConfig,
+    normalized_credential_skip_names,
+    normalized_execution_environment_skip_names,
+)
 from aap_migration.migration.state import MigrationState
 from aap_migration.resources import get_endpoint
 from aap_migration.utils.inventory_fk import parse_inventory_id_from_api_value
@@ -1193,6 +1197,7 @@ class CredentialExporter(ResourceExporter):
         client: AAPSourceClient,
         state: MigrationState,
         performance_config: PerformanceConfig,
+        skip_credential_names: list[str] | None = None,
     ):
         """Initialize credential exporter with credential type cache.
 
@@ -1200,10 +1205,37 @@ class CredentialExporter(ResourceExporter):
             client: AAP source client instance
             state: Migration state manager
             performance_config: Performance configuration
+            skip_credential_names: Credential names to skip (case-insensitive)
         """
         super().__init__(client, state, performance_config)
         self._credential_type_cache: dict[int, dict[str, Any]] = {}
         self._cache_loaded = False
+        self._skip_credential_names = normalized_credential_skip_names(skip_credential_names)
+
+    def _skip_credential(self, data: dict[str, Any]) -> bool:
+        if not self._skip_credential_names:
+            return False
+        name = data.get("name")
+        if not name or not isinstance(name, str):
+            return False
+        return name.strip().casefold() in self._skip_credential_names
+
+    async def _process_resource(
+        self, resource: dict[str, Any], resource_type: str
+    ) -> dict[str, Any] | None:
+        """Skip configured credential names during export."""
+        processed = await super()._process_resource(resource, resource_type)
+        if processed is None:
+            return None
+        if resource_type == "credentials" and self._skip_credential(processed):
+            self.stats["skipped_count"] += 1
+            logger.info(
+                "credential_skipped_by_config",
+                name=processed.get("name"),
+                source_id=processed.get("id"),
+            )
+            return None
+        return processed
 
     async def _load_credential_type_cache(self) -> None:
         """Pre-fetch all credential types into cache.
@@ -2443,6 +2475,7 @@ def create_exporter(
     state: MigrationState,
     performance_config: PerformanceConfig,
     skip_execution_environment_names: list[str] | None = None,
+    skip_credential_names: list[str] | None = None,
 ) -> ExporterProtocol:
     """Create appropriate exporter for resource type.
 
@@ -2452,6 +2485,7 @@ def create_exporter(
         state: Migration state manager
         performance_config: Performance configuration
         skip_execution_environment_names: Optional EE names to skip (export); defaults to no filter
+        skip_credential_names: Optional credential names to skip (export); defaults to no filter
 
     Returns:
         Exporter instance implementing ExporterProtocol
@@ -2504,6 +2538,14 @@ def create_exporter(
             state,
             performance_config,
             skip_execution_environment_names=skip_execution_environment_names,
+        )
+
+    if canonical_type == "credentials":
+        return CredentialExporter(
+            client,
+            state,
+            performance_config,
+            skip_credential_names=skip_credential_names,
         )
 
     return exporter_class(client, state, performance_config)

--- a/src/aap_migration/migration/importer.py
+++ b/src/aap_migration/migration/importer.py
@@ -13,7 +13,11 @@ from typing import Any
 from aap_migration.client.aap_target_client import AAPTargetClient
 from aap_migration.client.bulk_operations import BulkOperations
 from aap_migration.client.exceptions import APIError, ConflictError
-from aap_migration.config import PerformanceConfig, normalized_execution_environment_skip_names
+from aap_migration.config import (
+    PerformanceConfig,
+    normalized_credential_skip_names,
+    normalized_execution_environment_skip_names,
+)
 from aap_migration.migration.state import MigrationState
 from aap_migration.resources import get_endpoint, normalize_resource_type
 from aap_migration.utils.idempotency import compare_resources
@@ -3179,6 +3183,26 @@ class CredentialImporter(ResourceImporter):
     # Custom types start at ID 28+
     BUILTIN_CREDENTIAL_TYPE_MAX_ID = 27
 
+    def __init__(
+        self,
+        client: AAPTargetClient,
+        state: MigrationState,
+        performance_config: PerformanceConfig,
+        resource_mappings: dict[str, dict[str, str]] | None = None,
+        *,
+        skip_credential_names: frozenset[str] | None = None,
+    ):
+        super().__init__(client, state, performance_config, resource_mappings)
+        self._skip_credential_names = skip_credential_names or frozenset()
+
+    def _skip_credential(self, data: dict[str, Any]) -> bool:
+        if not self._skip_credential_names:
+            return False
+        name = data.get("name")
+        if not name or not isinstance(name, str):
+            return False
+        return name.strip().casefold() in self._skip_credential_names
+
     async def import_resource(
         self,
         resource_type: str,
@@ -3477,13 +3501,23 @@ class CredentialImporter(ResourceImporter):
             message="PATCHing pre-created credentials in target",
         )
 
+        to_import = [c for c in credentials if not self._skip_credential(c)]
+        skipped = len(credentials) - len(to_import)
+        if skipped:
+            self.stats["skipped_count"] += skipped
+            logger.info(
+                "credentials_skipped_by_config",
+                count=skipped,
+                message="Skipped by export.skip_credential_names",
+            )
+
         # Clean up transformer marker fields before import
-        for credential in credentials:
+        for credential in to_import:
             credential.pop("_encrypted_fields", None)
             credential.pop("_temp_credential_values", None)
 
         # All credentials go through the same PATCH flow via import_resource()
-        results = await self._import_parallel("credentials", credentials, progress_callback)
+        results = await self._import_parallel("credentials", to_import, progress_callback)
 
         logger.info(
             "credentials_import_completed",
@@ -5025,6 +5059,7 @@ def create_importer(
     performance_config: PerformanceConfig,
     resource_mappings: dict[str, dict[str, str]] | None = None,
     skip_execution_environment_names: list[str] | None = None,
+    skip_credential_names: list[str] | None = None,
 ) -> ResourceImporter:
     """Create appropriate importer for resource type.
 
@@ -5035,6 +5070,7 @@ def create_importer(
         performance_config: Performance configuration
         resource_mappings: Optional resource name mappings from config/mappings.yaml
         skip_execution_environment_names: EE names to skip (import); None means no name filter
+        skip_credential_names: Credential names to skip (import); None means no name filter
 
     Returns:
         Appropriate ResourceImporter subclass instance
@@ -5102,6 +5138,20 @@ def create_importer(
             performance_config,
             resource_mappings,
             skip_execution_environment_names=skip_frozen,
+        )
+
+    if canonical_type == "credentials":
+        skip_cred_frozen = (
+            normalized_credential_skip_names(skip_credential_names)
+            if skip_credential_names is not None
+            else frozenset()
+        )
+        return CredentialImporter(
+            client,
+            state,
+            performance_config,
+            resource_mappings,
+            skip_credential_names=skip_cred_frozen,
         )
 
     return importer_class(client, state, performance_config, resource_mappings)

--- a/src/aap_migration/migration/parallel_exporter.py
+++ b/src/aap_migration/migration/parallel_exporter.py
@@ -110,6 +110,7 @@ class ParallelExportCoordinator:
                     self.migration_state,
                     self.performance_config,
                     skip_execution_environment_names=self.export_config.skip_execution_environment_names,
+                    skip_credential_names=self.export_config.skip_credential_names,
                 )
             except NotImplementedError as e:
                 # No exporter for this resource type - skip it gracefully


### PR DESCRIPTION
…gration

Add skip_credential_names config option (defaults to 'Ansible Galaxy' and 'Default Execution Environment Registry Credential') so that credentials created automatically by the AAP installer are excluded from export, import, and cleanup. Follows the same pattern as skip_execution_environment_names.

Fixes https://github.com/redhat-cop/aap-bridge/issues/69.