### PR TITLE
docs: sync documentation to match current code

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -14,6 +14,12 @@
     "allowed_elements": ["div", "span", "br", "details", "summary"]
   },
 
+  // MD024: Allow duplicate headings across different sections (e.g. ### Added in each
+  // changelog version block), but still flag true duplicates within the same section.
+  "MD024": {
+    "siblings_only": true
+  },
+
   // MD041: First line heading - disabled
   "MD041": false,
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,120 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Source Version Support**: AAP 1.0, 1.1, 1.2, 2.0, 2.1, 2.2, 2.5, and 2.6 are now
+  supported as migration sources in addition to the original 2.3/2.4/2.5 paths
+- **Survey Spec Migration**: Job template and workflow job template survey specs are now
+  exported via `GET …/{id}/survey_spec/` and imported via `POST …/{id}/survey_spec/`
+- **Notification Template Associations**: Notification template relationships for job
+  templates (started/success/error) and workflow job templates (including approvals) are
+  now exported and imported as part of the template migration
+- **Nested Group Hierarchies**: Inventory group parent-child relationships are now fully
+  exported and recreated on the target
+- **Host-Group Associations**: Hosts are associated with their groups after bulk import
+  rather than being left unattached
+- **Constructed Inventory `input_inventories`**: The list of member inventories for
+  constructed inventories is now exported and re-linked on the target
+- **Inventory Source Auto-Sync**: After importing inventory sources the tool automatically
+  triggers a sync and waits for completion before proceeding to constructed inventories
+  and smart inventories, ensuring those depend on fresh host data
+- **Classic RBAC Migration (Users)**: Direct user resource role grants are exported from
+  `GET /users/{id}/roles/` and applied on the target AAP 2.6 RBAC model
+- **Classic RBAC Migration (Teams)**: Team resource role grants are exported from
+  `GET /teams/{id}/roles/` and applied on the target
+- **`role_definitions` Cleanup**: Custom role definitions are now deleted during the
+  cleanup phase; system-managed roles that return 400 are gracefully skipped
+- **`skip_credential_names` Configuration**: New `export.skip_credential_names` option
+  (defaults to `["Ansible Galaxy", "Default Execution Environment Registry Credential"]`)
+  excludes installer-created credentials from export, import, and cleanup — the same
+  pattern as `skip_execution_environment_names`
+- **`skip_execution_environment_names` Configuration**: New
+  `export.skip_execution_environment_names` option (defaults to the platform-managed EE names)
+  excludes default execution environments from export, import, and cleanup
+- **Configurable Inventory Source Sync**: New performance settings control the sync
+  timeout, polling interval, concurrency, and failure behaviour for post-import
+  inventory source updates
+- **CI/CD Docs Workflow**: GitHub Actions workflow added to publish MkDocs documentation
+  via `gh-deploy` on push to `main`
+- **AAP Token Retrieval Docs**: `curl` commands with `jq` for retrieving API tokens from
+  AAP 2.4 and earlier (`/api/v2/tokens/`) and AAP 2.6+ (`/api/gateway/v1/tokens/`) are
+  now documented
+
+### Changed
+
+- **All Migration Paths Marked Fully Supported**: The 2.3 → 2.6, 2.4 → 2.6, and
+  2.5 → 2.6 paths are all now marked as fully supported; messaging is standardised
+- **`inventory_sources` Re-ordered**: Inventory sources are now imported before
+  constructed inventories and smart inventories to satisfy sync dependencies
+- **Smart Inventories Deferred**: Smart inventory import is now a dedicated phase that
+  runs after inventory source sync completes, preventing membership lookup failures
+- **Users and Teams Phase Re-ordered**: Users and teams are now processed in phase 2
+  (immediately before `role_definitions`) so that job templates, workflows, and
+  inventories are already mapped when role grants are applied
+- **Error Output Simplified**: Console error output no longer renders full Rich
+  tracebacks with local variable dumps; errors render as a single summary line
+
+### Fixed
+
+- **Credentials – Same-Name Different Types**: Credentials sharing a name but with
+  different credential types were silently collapsed to one entry; the precheck and
+  importer now key on `(name, credential_type)` so both survive
+- **Credentials – Non-Unique Name/Org/Type**: Sources that contain multiple credentials
+  with an identical `(name, org, credential_type)` composite key are handled by always
+  CREATing a new credential; idempotency is guaranteed by `MigrationProgress` rather
+  than name matching
+- **Credentials – Duplicate Key on Import (400)**: When the target returns a 400
+  "duplicate key / already exists" error during credential import, the duplicate is
+  renamed to `<name> [src:<source_id>]` and retried so every source credential gets
+  its own distinct target entry; previous behaviour mapped all duplicates to a single
+  target credential, breaking downstream dependency resolution
+- **Precheck – Org-Scoped Resource Collisions**: Resources such as projects,
+  inventories, and job templates that share a name across different organizations were
+  silently deduplicated during the batch precheck; they are now keyed on
+  `(name, org_id)` so all entries are preserved
+- **Precheck – Parent-Scoped Resources**: Inventory sources, hosts, and groups that
+  share a name across different inventories were treated as globally unique; the
+  precheck now keys them on `(name, source_parent_id)` and resolves the parent ID
+  mapping before the existence check
+- **Precheck – Notification Templates and Schedules Scoping**: Both resource types were
+  treated as globally unique, causing same-name entries in different parent scopes to
+  be dropped; notification templates are now org-scoped and schedules are keyed by
+  `(name, unified_job_template)`
+- **Project Sync – Failure Detection**: Project SCM sync failures are now detected,
+  automatically retried up to `project_sync_max_retries` times, and the run is aborted
+  if the failure persists (configurable via `project_sync_fail_on_sync_failure`)
+- **Schedules – System-Job Schedules Excluded**: `system_job` type schedules are now
+  skipped during export, import, and cleanup to avoid 400 errors on the target
+- **Credential Types – Namespace Fallback**: Built-in credential types that were renamed
+  between AAP versions (e.g. the CyberArk lookup type) are now matched by stable
+  `namespace` when the name lookup fails, preventing spurious 404 errors
+- **User Team Memberships**: User-to-team memberships are now exported via
+  `users/<id>/teams/` and re-applied on import; a post-teams resync step ensures
+  membership is consistent even when users were imported before teams
+- **Vault Configuration Optional**: The `vault:` block in `config.yaml` is now
+  entirely optional; omitting it no longer raises a validation error at startup
+- **Cleanup – Inventory Sources Excluded**: Inventory sources are no longer deleted
+  during cleanup (they are managed by the parent inventory)
+- **Cleanup – Preserve Job History**: The cleanup status filter query is fixed so that
+  running jobs are correctly cancelled and historical job records are preserved
+- **Cleanup – Groups and Hosts Excluded**: Groups and hosts are skipped during the
+  cleanup phase; they are removed when their parent inventory is deleted
+- **Cleanup – Execution Environments Always Protected**: Managed EEs (e.g. Control
+  Plane Execution Environment) are now protected from deletion in `--full` mode as well
+  as the default mode; previously the `is_managed` guard only applied outside `--full`
+- **Cleanup – False Warning for Cascade-Deleted Phases**: The spurious warning for
+  phases that were already removed by cascade deletion is suppressed in the cleanup TUI
+- **Import – `notification_templates`, `credential_input_sources`, `rbac` Dispatch**:
+  These resource types were unreachable in the CLI method map and were silently skipped;
+  the dispatch table is corrected so all three are importable
+- **Import – Workflow Job Templates Dispatch**: `workflow_job_templates` was not
+  dispatching to `WorkflowImporter`; fixed so the importer is always called
+- **Client – 400 Pending Deletion Treated as Idempotent**: A `400` response indicating
+  that a resource is pending deletion is now treated as a skip rather than an error
+- **Instance Groups Exception Scoped to 2.5**: The instance groups API exception
+  handling that was applied to all source versions is now scoped to AAP 2.5 only
+
 ## [0.1.0] - 2025-12-05
 
 ### Added
@@ -17,7 +131,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - ETL pipeline for source-to-target AAP migrations
   - Support for all major AAP resource types: organizations, users, teams,
     credentials, credential types, execution environments, projects,
-    inventories, hosts, job templates, workflow job templates, and schedules
+    inventories, inventory sources, inventory groups, hosts, job templates,
+    workflow job templates, notification templates, and schedules
   - RBAC role assignment migration
   - Bulk API operations for high-performance host and inventory imports
 - **State Management**

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ migrations (e.g., 80,000+ hosts)
   capability
 - **Idempotency**: Safely resume interrupted migrations without creating
   duplicates
+- **Broad Source Version Support**: Migrate from AAP 1.0, 1.1, 1.2, 2.0, 2.1,
+  2.2, 2.3, 2.4, 2.5, or 2.6 to a target AAP 2.6 instance
+- **Complete Resource Coverage**: Organizations, users, teams, credentials,
+  execution environments, inventories, groups, hosts, projects, job templates,
+  workflow job templates (including nodes, survey specs, and notification
+  associations), schedules, RBAC role assignments, and more
+- **Classic RBAC Migration**: User and team resource role grants from AAP 1.0–2.5
+  are automatically translated to the AAP 2.6 RBAC model
+- **Inventory Source Sync**: Inventory sources are automatically synced after
+  import before constructed and smart inventories are created
 - **Professional Progress Display**: Rich-based live progress display with
   real-time metrics (rate, success/fail counts, timing)
 - **Flexible Output Modes**: Normal, quiet, CI/CD, and detailed modes for
@@ -70,11 +80,13 @@ uv sync
 
 ### Configuration
 
-The project includes configuration files with recommended default values. You need to set up your environment variables for AAP credentials and the database.
+The project includes configuration files with recommended default values. You need to set up
+your environment variables for AAP credentials and the database.
 
 #### 1. Database Setup
 
-The tool requires a PostgreSQL database to track migration state. You must create this database before running the tool. The tool will automatically create the necessary tables on first run.
+The tool requires a PostgreSQL database to track migration state. You must create this database
+before running the tool. The tool will automatically create the necessary tables on first run.
 
 ```bash
 
@@ -118,12 +130,25 @@ cp .env.example .env
 
 Edit `.env` with your AAP instance details and database connection string.
 
-**Critical AAP 2.6 Note:** The Target URL must point to the **Platform Gateway** (`/api/controller/v2`), not the direct controller API.
+**Critical AAP 2.6 Note:** The Target URL must point to the **Platform Gateway**
+(`/api/controller/v2`), not the direct controller API.
 
-To get your tokens easily, you can get them through the API with a curl command
-* For AAP 2.4 and earlier, `curl -k -X POST -u "<<username>>:<<password>>" -H "Content-Type: application/json" -d '{"description": "CLI Token", "scope": "write"}' https://<<aap_base_url>>/api/v2/tokens/ | jq -r '.token'`
-* For AAP 2.6 and later,  `curl -k -X POST -u "<<username>>:<<password>>" -H "Content-Type: application/json" -d '{"description": "CLI Token", "scope": "write"}' https://<<aap_base_url>>/api/gateway/v1/tokens/ | jq -r '.token'`
+To retrieve API tokens via the command line (take care to not get the password in your
+SHELL history):
 
+```bash
+# AAP 2.5 and earlier
+curl -k -X POST -u "<username>:<password>" \
+  -H "Content-Type: application/json" \
+  -d '{"description": "CLI Token", "scope": "write"}' \
+  https://<aap_base_url>/api/v2/tokens/ | jq -r '.token'
+
+# AAP 2.6 and later (Platform Gateway)
+curl -k -X POST -u "<username>:<password>" \
+  -H "Content-Type: application/json" \
+  -d '{"description": "CLI Token", "scope": "write"}' \
+  https://<aap_base_url>/api/gateway/v1/tokens/ | jq -r '.token'
+```
 
 ```bash
 
@@ -154,8 +179,14 @@ Review and adjust `config/config.yaml` for your environment:
 - **Performance settings**: Adjust batch sizes and concurrency based on your AAP instance capacity
 - **Logging**: Configure log levels and file paths
 - **Migration phases**: Enable/disable specific resource types
+- **`export.skip_execution_environment_names`**: List of EE names to exclude from
+  export/import/cleanup (defaults to the platform-managed EEs). Set to `[]` to migrate all EEs.
+- **`export.skip_credential_names`**: List of credential names to exclude (defaults to
+  `["Ansible Galaxy", "Default Execution Environment Registry Credential"]`). These are
+  recreated automatically by the AAP installer.
 
-1. Update `config/mappings.yaml` if you need to rename resources during migration (e.g., credential types with different names between AAP versions).
+Update `config/mappings.yaml` if you need to rename resources during migration (e.g.,
+credential types with different names between AAP versions).
 
 ### Usage
 
@@ -289,19 +320,35 @@ aap-bridge migrate resume --checkpoint inventories_batch_50
 
 ### Idempotency
 
-The tool tracks all migrated resources in a state database, ensuring that running the migration multiple times is safe and won't create duplicates.
+The tool tracks all migrated resources in a state database, ensuring that running the migration
+multiple times is safe and won't create duplicates.
 
 ## Migration Order
 
 The tool migrates resources in the correct dependency order:
 
-1. Organizations, Labels, Users, Teams
-2. Credential Types, Credentials
-3. Projects, Execution Environments
-4. Inventories (bulk operations)
-5. Hosts (bulk operations, 200/batch)
-6. Job Templates, Workflows
-7. RBAC role assignments
+1. Organizations
+2. Labels
+3. Users
+4. Teams
+5. Credential Types
+6. Credentials
+7. Credential Input Sources
+8. Execution Environments
+9. Projects (with sync wait)
+10. Inventories
+11. Inventory Sources (with auto-sync wait)
+12. Constructed Inventories
+13. Inventory Groups (with nested hierarchy)
+14. Hosts (bulk operations, 200/batch) + host-group associations
+15. Notification Templates
+16. Job Templates (with survey specs and notification associations)
+17. Workflow Job Templates (with nodes, survey specs, and notification associations)
+18. System Job Templates
+19. Schedules
+20. Role Definitions (AAP 2.6 DAB RBAC)
+21. User Role Assignments
+22. Team Role Assignments
 
 ## Documentation
 
@@ -394,17 +441,20 @@ make check
 
 ### Encrypted Credentials
 
-**Important**: Encrypted credentials cannot be extracted from source AAP via API. Passwords, SSH keys, and secret fields will show as `$encrypted$`.
+**Important**: Encrypted credentials cannot be extracted from source AAP via API. Passwords,
+SSH keys, and secret fields will show as `$encrypted$`.
 
 **Solution**: Credentials must be manually recreated in HashiCorp Vault before migration.
 
 ### Platform Gateway
 
-AAP 2.6 routes all API calls through the Platform Gateway at `https://<gateway>/api/controller/v2/`. The tool automatically handles this routing.
+AAP 2.6 routes all API calls through the Platform Gateway at
+`https://<gateway>/api/controller/v2/`. The tool automatically handles this routing.
 
 ## Project Status
 
-**Current Version**: 0.1.0 - Initial Release
+**Current Version**: 0.1.0+ (active development — see [CHANGELOG.md](CHANGELOG.md) for the
+full list of changes since the initial release)
 
 See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -418,7 +468,8 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## License
 
-This project is licensed under the GNU General Public License v3.0 - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the GNU General Public License v3.0 - see the
+[LICENSE](LICENSE) file for details.
 
 ## Security
 
@@ -426,7 +477,8 @@ For security concerns and vulnerability reporting, please see [SECURITY.md](SECU
 
 ## Support
 
-- **Issues**: Report bugs and request features via [GitHub Issues](https://github.com/redhat-cop/aap-bridge/issues)
+- **Issues**: Report bugs and request features via
+  [GitHub Issues](https://github.com/redhat-cop/aap-bridge/issues)
 - **Security**: Report vulnerabilities privately (see [SECURITY.md](SECURITY.md))
 
 ## Acknowledgments

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -62,25 +62,70 @@ paths:
 
 ```yaml
 performance:
-  max_concurrent: 10           # Concurrent API requests
+  max_concurrent: 20           # Concurrent API requests
   batch_sizes:
-    organizations: 50
-    inventories: 100
-    hosts: 200                 # Maximum for bulk API
+    organizations: 100
+    inventories: 200           # Maximum API page size for optimal performance
+    hosts: 200                 # Maximum API page size (required for bulk operations)
     credentials: 50
-  rate_limit:
-    requests_per_second: 50
-    burst_size: 100
+  rate_limit: 25               # Requests per second
+
+  # Inventory source sync (runs after import before constructed/smart inventories)
+  inventory_source_update_job_timeout_seconds: 3600
+  inventory_source_update_poll_interval_seconds: 3
+  inventory_source_sync_max_concurrent: 5
+  inventory_source_sync_fail_on_job_failure: false  # Set true to abort on sync failure
+
+  # Project sync
+  project_sync_timeout: 600
+  project_sync_poll_interval: 10
+  project_sync_max_retries: 2
+  project_sync_fail_on_sync_failure: true
+
+```
+
+### Export Settings
+
+```yaml
+export:
+  # Skip hosts managed by inventory sources (recreated by sync on target)
+  skip_dynamic_hosts: true
+  skip_smart_inventories: false
+  skip_pending_deletion_inventories: true
+  skip_hosts_with_inventory_sources: false
+
+  # Installer-created execution environments – excluded by default.
+  # Set to [] to migrate all EEs.
+  skip_execution_environment_names:
+    - Control Plane Execution Environment
+    - Default execution environment
+    - Hub Default execution environment
+    - Hub Minimal execution environment
+    - Minimal execution environment
+
+  # Installer-created credentials – excluded by default.
+  # The AAP installer recreates these automatically in the target environment.
+  # Set to [] to migrate all credentials.
+  skip_credential_names:
+    - Ansible Galaxy
+    - Default Execution Environment Registry Credential
+
+  records_per_file: 1000  # Max records per split file
 
 ```
 
 ### Cleanup Settings
 
+Cleanup-related settings live under the `performance:` section:
+
 ```yaml
-cleanup:
-  skip_default_resources: true  # Skip Default org, admin user
-  batch_size: 100
-  max_concurrent: 5
+performance:
+  cleanup_max_concurrent: 50        # Maximum concurrent deletions
+  cleanup_job_cancel_concurrency: 10  # Maximum concurrent job cancellations (≤25 to prevent gateway overload)
+  cleanup_page_fetch_concurrency: 10  # Maximum concurrent page fetches during resource discovery
+  cleanup_job_finish_timeout: 300   # Seconds to wait for cancelled jobs to finish
+  cleanup_job_poll_interval: 5      # Seconds between job status checks
+  host_cleanup_batch_size: 200      # Hosts per batch during cleanup (max 500 - AAP limit)
 
 ```
 
@@ -88,9 +133,10 @@ cleanup:
 
 ```yaml
 logging:
-  console_level: WARNING        # Console output level
+  level: WARNING               # Console output level
   file_level: DEBUG            # File log level
-  log_file: ./logs/aap-bridge.log
+  file: logs/migration.log     # Log file path
+  format: json                 # Log format (json or console)
 
 ```
 
@@ -155,6 +201,7 @@ performance:
   batch_sizes:
     hosts: 200
     inventories: 200
+  rate_limit: 25
 
 ```
 
@@ -165,7 +212,6 @@ Reduce concurrent requests:
 ```yaml
 performance:
   max_concurrent: 5
-  rate_limit:
-    requests_per_second: 20
+  rate_limit: 20
 
-```text
+```

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -8,7 +8,42 @@ in the repository.
 
 ## Version History
 
-### v0.1.0 (Current)
+### Unreleased (since v0.1.0)
+
+**New Features:**
+
+- Source version support expanded to AAP 1.0, 1.1, 1.2, 2.0, 2.1, 2.2, 2.5, and 2.6
+- Survey spec migration for job templates and workflow job templates
+- Notification template association migration (started/success/error/approvals)
+- Nested inventory group hierarchy export and import
+- Host-to-group associations applied after bulk import
+- Constructed inventory `input_inventories` exported and re-linked on target
+- Automatic inventory source sync after import (with configurable timeout/polling)
+- Smart inventory import deferred until after inventory source sync
+- Classic RBAC migration for user and team resource role grants
+- `role_definitions` included in cleanup phase
+- `skip_credential_names` configuration option (defaults exclude installer-created credentials)
+- `skip_execution_environment_names` configuration option (defaults exclude platform-managed EEs)
+- MkDocs GitHub Actions deployment workflow
+
+**Bug Fixes:**
+
+- Credential deduplication: same-name/different-type and non-unique name+org+type cases
+  handled correctly
+- Batch precheck scoping fixed for org-scoped, parent-scoped, notification template, and
+  schedule resources
+- Project sync failure detection with retry and configurable abort
+- System-job schedules excluded from export/import/cleanup
+- Managed credential types matched by namespace when name differs between versions
+- User team memberships exported and re-applied on import
+- Vault configuration is now optional
+- Cleanup: inventory sources excluded, job history preserved, groups/hosts skipped
+- Managed execution environments always protected from deletion (including in `--full` mode)
+- Import dispatch table corrected for `notification_templates`, `credential_input_sources`,
+  `rbac`, and `workflow_job_templates`
+- 400 "pending deletion" responses treated as idempotent skips
+
+### v0.1.0
 
 Initial release of AAP Bridge.
 
@@ -30,23 +65,26 @@ Initial release of AAP Bridge.
 - Teams
 - Credential Types
 - Credentials
+- Credential Input Sources
 - Execution Environments
 - Inventories
 - Inventory Sources
 - Inventory Groups
 - Hosts
-- Instances
-- Instance Groups
 - Projects
+- Notification Templates
 - Job Templates
 - Workflow Job Templates
+- System Job Templates
 - Schedules
+- Role Definitions
+- User Role Assignments
+- Team Role Assignments
 
 **Known Limitations:**
 
-- Encrypted credentials cannot be migrated (API limitation)
-- RBAC assignments require manual verification
-- Workflow approval nodes need manual setup
+- Encrypted credentials cannot be migrated via API (use HashiCorp Vault or manual entry)
+- Workflow approval nodes require manual review after migration
 
 ---
 

--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -1,6 +1,7 @@
-# Source-Version Compatibility Matrix (AAP 2.3, 2.4, 2.5 → 2.6)
+# Source-Version Compatibility Matrix
 
-This document defines the supported source-to-target migration paths for the AAP Bridge tool and documents known version-specific exceptions.
+This document defines the supported source-to-target migration paths for the AAP Bridge tool
+and documents known version-specific exceptions.
 
 ## Support Status Key
 
@@ -14,35 +15,39 @@ This document defines the supported source-to-target migration paths for the AAP
 
 | Source Version | Target Version | Status | Evidence Date | Notes |
 |:---|:---|:---|:---|:---|
-| AAP 2.3 | AAP 2.6 | **Supported** | 2026-03-24 | Primary migration path. Fully tested across all resource types. |
-| AAP 2.4 | AAP 2.6 | **Partial** | 2026-03-24 | Core resource families verified. Inventory plugin changes may require review. |
-| AAP 2.5 | AAP 2.6 | **Partial** | 2026-03-24 | Schema differences are minimal. RBAC model changes require manual review. |
+| AAP 1.0 | AAP 2.6 | **Supported** | 2026-04-25 | Primary migration path. Fully tested. |
+| AAP 1.1 | AAP 2.6 | **Supported** | 2026-04-25 | Primary migration path. Fully tested. |
+| AAP 1.2 | AAP 2.6 | **Supported** | 2026-04-25 | Primary migration path. Fully tested. |
+| AAP 2.0 | AAP 2.6 | **Supported** | 2026-04-25 | Primary migration path. Fully tested. |
+| AAP 2.1 | AAP 2.6 | **Supported** | 2026-04-25 | Primary migration path. Fully tested. |
+| AAP 2.2 | AAP 2.6 | **Supported** | 2026-04-25 | Primary migration path. Fully tested. |
+| AAP 2.3 | AAP 2.6 | **Supported** | 2026-04-25 | Primary migration path. Fully tested. |
+| AAP 2.4 | AAP 2.6 | **Supported** | 2026-04-25 | Primary migration path. Fully tested. |
+| AAP 2.5 | AAP 2.6 | **Supported** | 2026-04-25 | Primary migration path. Fully tested. |
+| AAP 2.6 | AAP 2.6 | **Supported** | 2026-04-25 | Same-version migration path. Schema fully compatible. |
 
 ## Known Version-Specific Exceptions
 
 ### All Source Versions → AAP 2.6
 
-- **Encrypted Credentials**: Encrypted field values (passwords, SSH keys) cannot be extracted via the source AAP API. These must be migrated using HashiCorp Vault or re-entered manually on the target.
-- **Platform Gateway**: All API calls to the target AAP 2.6 instance must be routed through the Platform Gateway.
+- **Encrypted Credentials**: Encrypted field values (passwords, SSH keys) cannot be extracted
+  via the source AAP API. These must be migrated using HashiCorp Vault or re-entered manually
+  on the target.
 
-### AAP 2.3 → AAP 2.6
+### AAP 2.5+ → AAP 2.6
 
-- **Custom Credential Types**: May require manual pre-creation on the target if they use complex schema features not fully handled by the automated transformation.
-
-### AAP 2.4 → AAP 2.6
-
-- **Inventory Plugins**: Configuration format for certain inventory plugins changed between 2.4 and 2.6. Review imported inventories that use SCM or cloud-based sources.
-
-### AAP 2.5 → AAP 2.6
-
-- **RBAC Model**: The RBAC model was significantly restructured in AAP 2.6. While basic user and team assignments are migrated, complex custom role definitions should be manually reviewed on the target.
+- **Instance Groups**: Instance groups referenced by RBAC assignments must exist on the target
+  with the same name before migration.
 
 ## Verifying Your Migration Path
 
-The `aap-bridge prep` command automatically discovers the versions of your source and target instances and validates them against this matrix.
+The `aap-bridge prep` command automatically discovers the versions of your source and target
+instances and validates them against this matrix.
 
 ```bash
 aap-bridge prep --config config.yaml
 ```
 
-If your version pair is not fully supported, the tool will issue a warning and list known exceptions for that path. You can override an "Unsupported" status using the `--force` flag, but this is recommended for experimental use only.
+If your version pair is not fully supported, the tool will issue a warning and list known
+exceptions for that path. You can override an "Unsupported" status using the `--force` flag,
+but this is recommended for experimental use only.

--- a/docs/user-guide/filtering-and-skipping.md
+++ b/docs/user-guide/filtering-and-skipping.md
@@ -1,12 +1,15 @@
 # Filtering and Skipping Logic
 
-This document explains why resource counts in the target environment may be lower than the source. AAP Bridge applies various filters and skip conditions across different phases to ensure a clean, consistent migration.
+This document explains why resource counts in the target environment may be lower than the
+source. AAP Bridge applies various filters and skip conditions across different phases to
+ensure a clean, consistent migration.
 
 ## Overview
 
 Resources can be filtered or skipped for several reasons:
 
-- **Intentional exclusion**: Dynamic hosts, smart inventories, installer-created default credentials, and disabled schedules are excluded by design
+- **Intentional exclusion**: Dynamic hosts, smart inventories, installer-created default
+  credentials, and disabled schedules are excluded by design
 - **Dependency validation**: Resources with missing dependencies cannot be migrated
 - **Idempotency**: Already-migrated resources are skipped to prevent duplicates
 - **System constraints**: Some resources are read-only or non-deletable
@@ -28,6 +31,7 @@ These filters are controlled via `config.yaml` under the `export:` section:
 | `skip_pending_deletion_inventories` | `true` | Inventories | Excludes inventories marked for deletion in the source. |
 | `skip_hosts_with_inventory_sources` | `true` | Hosts | Same as `skip_dynamic_hosts` - excludes hosts with `has_inventory_sources=true`. |
 | `skip_credential_names` | `["Ansible Galaxy", "Default Execution Environment Registry Credential"]` | Credentials | Excludes installer-created default credentials by name (case-insensitive). The target installer recreates these automatically. Use `[]` to migrate all credentials. |
+| `skip_execution_environment_names` | `["Control Plane Execution Environment", "Default execution environment", ...]` | Execution Environments | Excludes platform-managed EEs by name (case-insensitive). These are recreated by the AAP installer. Use `[]` to migrate all EEs. |
 
 **Example configuration:**
 
@@ -40,6 +44,13 @@ export:
   skip_credential_names:
     - Ansible Galaxy
     - Default Execution Environment Registry Credential
+  # Remove entries or use [] to migrate these execution environments
+  skip_execution_environment_names:
+    - Control Plane Execution Environment
+    - Default execution environment
+    - Hub Default execution environment
+    - Hub Minimal execution environment
+    - Minimal execution environment
 ```
 
 ### Built-in Filters (Not Configurable)
@@ -50,7 +61,8 @@ export:
 | Credential Types | All exported | Both managed (built-in) and custom types are exported for mapping purposes. |
 
 !!! note "Dynamic Hosts"
-    Hosts managed by inventory sources (EC2, VMware, etc.) are excluded because they will be automatically recreated when the inventory source syncs on the target controller.
+    Hosts managed by inventory sources (EC2, VMware, etc.) are excluded because they will be
+    automatically recreated when the inventory source syncs on the target controller.
 
 ---
 
@@ -78,7 +90,8 @@ Resources are skipped if their **required** dependencies weren't exported or don
 
 ### External Credential Types
 
-Credentials using external credential types (custom types from the source) are skipped if the credential type cannot be mapped to the target environment.
+Credentials using external credential types (custom types from the source) are skipped if the
+credential type cannot be mapped to the target environment.
 
 **Log message:** `skipping_credential_external_type_unmapped`
 
@@ -125,6 +138,8 @@ The cleanup command excludes certain resources that cannot be deleted.
 |---------------|--------|
 | Labels | API returns 405 Method Not Allowed |
 | System Job Templates | Built-in, cannot be deleted |
+| Managed Execution Environments | `is_managed=true` EEs (e.g. Control Plane EE) are protected unconditionally |
+| Named EEs in `skip_execution_environment_names` | Excluded by name list even in `--full` mode |
 
 ### Excluded Endpoint Categories
 
@@ -143,6 +158,7 @@ The cleanup command excludes certain resources that cannot be deleted.
 | Export | Dynamic hosts (inventory source managed) | Yes | Check `skip_dynamic_hosts` setting |
 | Export | Smart/pending deletion inventories | Yes | Check `skip_smart_inventories` setting |
 | Export | Installer-created default credentials | Yes | Check `skip_credential_names` setting |
+| Export | Platform-managed execution environments | Yes | Check `skip_execution_environment_names` setting |
 | Export | Disabled schedules | No | Only enabled schedules are exported |
 | Transform | Missing organization | No | Check export logs for organization |
 | Transform | Missing credential type | No | Ensure credential types exported first |
@@ -164,21 +180,28 @@ When comparing source and target counts, consider:
 1. **Hosts**: If `skip_dynamic_hosts=true` (default), dynamic hosts won't be counted
 2. **Inventories**: Smart inventories and pending deletion inventories are excluded
 3. **Schedules**: Disabled schedules are not exported
-4. **Credentials**: Installer-created defaults (`Ansible Galaxy`, `Default Execution Environment Registry Credential`) are skipped by default; others may be skipped due to unmapped external types
+4. **Credentials**: Installer-created defaults (`Ansible Galaxy`,
+   `Default Execution Environment Registry Credential`) are skipped by default; others may be
+   skipped due to unmapped external types
+5. **Execution Environments**: Platform-managed EEs (e.g. `Control Plane Execution Environment`)
+   are skipped and protected from deletion by default
 
 ### Investigating Discrepancies
 
 1. **Check export logs** for `skipped` entries:
+
    ```bash
    grep "skipped" logs/migration.log | jq '.resource_type, .reason'
    ```
 
 2. **Check transform logs** for dependency failures:
+
    ```bash
    grep "required_dependency_missing" logs/migration.log
    ```
 
 3. **Review configuration** in `config.yaml`:
+
    ```yaml
    export:
      skip_dynamic_hosts: true      # Are dynamic hosts being skipped?
@@ -186,6 +209,7 @@ When comparing source and target counts, consider:
    ```
 
 4. **Check state database** for import status:
+
    ```bash
    aap-bridge status --resource-type hosts
    ```
@@ -210,7 +234,12 @@ export:
 
   # Include installer-created default credentials (normally recreated by the target installer)
   skip_credential_names: []
+
+  # Include platform-managed execution environments (normally recreated by the target installer)
+  skip_execution_environment_names: []
 ```
 
 !!! warning "Changing Defaults"
-    The default filters exist for good reasons. Dynamic hosts will be recreated (and potentially duplicated) when inventory sources sync. Smart inventories may not function correctly if their source inventories differ.
+    The default filters exist for good reasons. Dynamic hosts will be recreated (and potentially
+    duplicated) when inventory sources sync. Smart inventories may not function correctly if
+    their source inventories differ.

--- a/docs/user-guide/migration-workflow.md
+++ b/docs/user-guide/migration-workflow.md
@@ -7,9 +7,9 @@ This guide explains the complete AAP migration process.
 AAP Bridge follows an ETL (Export, Transform, Load) pattern:
 
 ```text
-┌──────────┐    ┌───────────┐    ┌──────────┐    ┌────────┐    ┌─────────────────┐
-│   Prep   │───▶│  Export   │───▶│Transform │───▶│ Import │───▶│ Synchronise │
-└──────────┘    └───────────┘    └──────────┘    └────────┘    └─────────────────┘
+┌──────────┐    ┌──────────┐    ┌───────────┐    ┌────────┐    ┌──────────┐
+│   Prep   │──▶│  Export  │──▶│ Transform │──▶│ Import │──▶│ Validate │
+└──────────┘    └──────────┘    └───────────┘    └────────┘    └──────────┘
 
 ```
 
@@ -54,21 +54,23 @@ aap-bridge export
 
 **Export Order:**
 
-| Order | Resources |
-| --- | --- |
-| 1 | Organizations |
-| 2 | Labels |
-| 3 | Users, Teams |
-| 4 | Credential Types, Credentials |
-| 5 | Execution Environments |
-| 6 | Inventories |
-| 7 | Inventory Sources, Inventory Groups |
-| 8 | Hosts |
-| 9 | Instances, Instance Groups |
-| 10 | Projects |
-| 11 | Job Templates |
-| 12 | Workflow Job Templates |
-| 13 | Schedules |
+| Order | Resources | Notes |
+| --- | --- | --- |
+| 1 | Organizations | Foundation resource |
+| 2 | Labels | |
+| 3 | Users, Teams | Includes team membership and role grants |
+| 4 | Credential Types, Credentials, Credential Input Sources | |
+| 5 | Execution Environments | Default platform EEs are skipped by default |
+| 6 | Inventories | Smart and constructed inventories exported separately |
+| 7 | Inventory Sources | Includes cloud/SCM source configuration |
+| 8 | Inventory Groups | Includes nested group hierarchy |
+| 9 | Hosts | Dynamic hosts skipped by default |
+| 10 | Projects | |
+| 11 | Notification Templates | |
+| 12 | Job Templates | Includes survey spec and notification associations |
+| 13 | Workflow Job Templates | Includes nodes, survey spec, and notification associations |
+| 14 | Schedules | System-job schedules excluded |
+| 15 | Role Definitions | AAP 2.6 DAB RBAC custom role definitions |
 
 **Output Structure:**
 
@@ -130,7 +132,20 @@ aap-bridge import
 
 **Import Features:**
 
-- **Bulk Operations**: Hosts imported 200 at a time
+- **Bulk Operations**: Hosts imported 200 at a time via the AAP bulk API
+- **Host-Group Associations**: Hosts are associated with their groups after bulk import
+- **Inventory Source Sync**: After importing inventory sources, the tool triggers a sync and
+  waits for completion before moving to constructed and smart inventories
+- **Smart Inventory Deferral**: Smart inventories are imported in a dedicated phase after
+  inventory source sync to ensure correct host membership
+- **Survey Specs**: Job template and workflow job template survey specs are posted after
+  template creation
+- **Notification Associations**: Notification template relationships
+  (started/success/error/approvals) are applied after template creation
+- **Nested Groups**: Inventory group parent-child relationships are recreated after all groups
+  are imported
+- **Classic RBAC Translation**: User and team role grants from AAP 2.3–2.5 are translated to
+  the AAP 2.6 DAB RBAC model
 - **Idempotency**: Skips already-migrated resources
 - **Conflict Resolution**: Updates or skips existing resources
 - **Checkpointing**: Can resume from any failure point
@@ -185,25 +200,41 @@ Understanding dependencies is crucial for migration:
 ```text
 Organizations
     ├── Users (member of)
+    │       └── Team memberships
     ├── Teams (belongs to)
+    │       └── Resource role grants
     ├── Credentials (owned by)
     ├── Projects (belongs to)
     └── Inventories (belongs to)
-            ├── Inventory Sources
-            ├── Inventory Groups
-            └── Hosts
+            ├── Inventory Sources → sync → Smart Inventories
+            ├── Inventory Groups (with nested hierarchy)
+            │       └── Hosts (associated after bulk import)
+            └── Constructed Inventories (after inventory source sync)
 
 Credential Types (standalone)
     └── Credentials (uses)
+            └── Credential Input Sources
 
 Execution Environments (standalone)
+
+Notification Templates (org-scoped)
 
 Job Templates
     ├── Project (uses)
     ├── Inventory (uses)
     ├── Credentials (uses)
-    └── Execution Environment (uses)
+    ├── Execution Environment (uses)
+    ├── Survey Spec (sub-resource)
+    └── Notification Associations (started/success/error)
 
+Workflow Job Templates
+    ├── Nodes (embedded, including approval templates)
+    ├── Survey Spec (sub-resource)
+    └── Notification Associations (started/success/error/approvals)
+
+Role Definitions (AAP 2.6 DAB RBAC)
+    ├── Role User Assignments
+    └── Role Team Assignments
 ```
 
 ## Best Practices

--- a/src/aap_migration/resources.py
+++ b/src/aap_migration/resources.py
@@ -129,6 +129,7 @@ COMPATIBILITY_MATRIX: list[VersionPath] = [
         notes="Same-version migration path. Schema fully compatible.",
         known_exceptions=[
             "Encrypted credentials cannot be extracted from source API",
+            "Instance groups referenced by RBAC assignments must exist on the target with the same name",
         ],
     ),
 ]

--- a/tests/unit/test_version_compatibility.py
+++ b/tests/unit/test_version_compatibility.py
@@ -26,12 +26,12 @@ def test_version_path_major_minor_matching():
 
 def test_version_path_unsupported():
     """Test lookup for unsupported version pair."""
-    # 2.0 is not in our matrix
-    path = get_version_path("2.0.0", "2.6.0")
-    assert path is None
-
     # Target 2.7 is not in our matrix
     path = get_version_path("2.3.0", "2.7.0")
+    assert path is None
+
+    # Source 3.0 is not in our matrix
+    path = get_version_path("3.0.0", "2.6.0")
     assert path is None
 
 


### PR DESCRIPTION
- Compatibility matrix: mark all source versions as Supported (matching resources.py); trim exceptions to only those in COMPATIBILITY_MATRIX; expand AAP 2.5 instance groups note to AAP 2.5+
- configuration.md: fix batch sizes, max_concurrent, rate_limit (int not object), cleanup settings (performance keys, not a cleanup: block), and logging field names (level/file, not console_level/log_file)
- migration-workflow.md: fix diagram last stage (Validate not Synchronise); remove Instances/Instance Groups from export order (not a migrated type)
- Migration order in README.md: reorder to match MIGRATION_PHASES in coordinator.py; one resource type per line; add System Job Templates, User/Team Role Assignments; remove Smart Inventories (not a named phase)
- changelog.md (docs): one resource per line; add missing types
- CHANGELOG.md: fix v0.1.0 resource list; wrap long lines
- .markdownlint.jsonc: enable MD024 siblings_only for Keep a Changelog format
- test_version_compatibility.py: fix broken assertion that 2.0 → 2.6 returns None (2.0 is in the matrix); replace with correct 3.0 → 2.6 check
- All modified .md files: wrap prose lines to ≤100 chars (MD013)

Fixes https://github.com/redhat-cop/aap-bridge/issues/20.
Fixes https://github.com/redhat-cop/aap-bridge/issues/60.
