### PR TITLE
docs: clarify 2.5+ RBAC migration coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - **Classic RBAC Migration (Users)**: Direct user resource role grants are exported from
   `GET /users/{id}/roles/` and applied on the target AAP 2.5+ RBAC model
 - **Classic RBAC Migration (Teams)**: Team resource role grants are exported from
-  `GET /teams/{id}/roles/` and applied on the target
+  `GET /teams/{id}/roles/` and applied on the target AAP 2.5+ RBAC model
+- **AAP 2.5+ RBAC Fully Implemented (2.5+ Sources)**: New-model RBAC resources are
+  fully migrated and functional for AAP 2.5+ sources, including `role_definitions`,
+  `role_user_assignments`, and `role_team_assignments`
 - **`role_definitions` Cleanup**: Custom role definitions are now deleted during the
   cleanup phase; system-managed roles that return 400 are gracefully skipped
 - **`skip_credential_names` Configuration**: New `export.skip_credential_names` option

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -20,7 +20,9 @@ in the repository.
 - Constructed inventory `input_inventories` exported and re-linked on target
 - Automatic inventory source sync after import (with configurable timeout/polling)
 - Smart inventory import deferred until after inventory source sync
-- Classic RBAC migration for user and team resource role grants
+- Classic RBAC migration for user and team resource role grants to the target AAP 2.5+ RBAC model
+- For AAP 2.5+ sources, new-model RBAC migration is fully implemented and functional for
+  `role_definitions`, `role_user_assignments`, and `role_team_assignments`
 - `role_definitions` included in cleanup phase
 - `skip_credential_names` configuration option (defaults exclude installer-created credentials)
 - `skip_execution_environment_names` configuration option (defaults exclude platform-managed EEs)
@@ -47,6 +49,7 @@ in the repository.
 - Managed execution environments always protected from deletion (including in `--full` mode)
 - Import dispatch table corrected for `notification_templates`, `credential_input_sources`,
   `rbac`, and `workflow_job_templates`
+- Instance group RBAC API exception handling is now scoped to AAP 2.5+ sources only
 - 400 "pending deletion" responses treated as idempotent skips
 - Credential type reruns now map "already exists" conflicts and mark completed state
 - Host bulk import reruns now skip already-mapped hosts and persist host progress state


### PR DESCRIPTION
Document that AAP 2.5+ source migrations fully support the new RBAC model, including role definitions and role assignments, and align changelog wording across docs.