### PR TITLE
Fix infinite pagination loop in list_resources()

### DIFF
--- a/src/aap_migration/client/aap_target_client.py
+++ b/src/aap_migration/client/aap_target_client.py
@@ -547,11 +547,29 @@ class AAPTargetClient(BaseAPIClient):
             next_url = response.get("next")
             if next_url:
                 # Extract path from full URL for next request
-                from urllib.parse import urlparse
+                from urllib.parse import parse_qsl, urlparse
 
                 parsed = urlparse(next_url)
-                endpoint = parsed.path.replace("/api/controller/v2/", "")
-                params = {}  # Next URL already has query params
+                next_endpoint = parsed.path.replace("/api/controller/v2/", "")
+                # parsed.path is only the path (inventories/) — the query string
+                # (?page=2&name__in=...) lives in parsed.query, which is thrown away.
+                # So every "next page" request goes to the bare endpoint with no page
+                # and no filter, which returns page 1 again, whose next is still page 2
+                # → it loops forever, re-fetching page 1.
+                # It only triggers when a result set exceeds one page (page_size 100)
+                # — exactly your large inventories/groups.
+                next_params = dict(parse_qsl(parsed.query))
+                if next_endpoint == endpoint and next_params == params:
+                    # Defensive guard: identical next request means no forward
+                    # progress; stop rather than loop indefinitely.
+                    logger.warning(
+                        "pagination_no_progress",
+                        resource_type=resource_type,
+                        endpoint=next_endpoint,
+                    )
+                    break
+                endpoint = next_endpoint
+                params = next_params
             else:
                 endpoint = None
 


### PR DESCRIPTION
## Summary

Fixes #97 - Critical bug causing infinite pagination loop in `list_resources()` method, which resulted in 90+ minute hangs during import pre-check phase.

## Problem

The `list_resources()` method was discarding query parameters when following pagination `next` URLs, causing it to repeatedly fetch page 1 in an infinite loop. This only manifested when result sets exceeded 100 items (the page size).

**Customer Impact:**
- Import hung for 90+ minutes on groups (1067 items)
- No error messages (all requests returned 200 OK)
- Process appeared stuck at 0% progress
- Only affected second+ import runs (when pre-check was active)

## Root Cause

**Before (buggy):**
\`\`\`python
parsed = urlparse(next_url)
endpoint = parsed.path.replace("/api/controller/v2/", "")
params = {}  # ❌ Discards all query parameters from next URL
\`\`\`

**Problem:**
- \`parsed.path\` only contains the URL path (\`/api/controller/v2/groups/\`)
- \`parsed.query\` contains the query string (\`page=2&name__in=...\`) but was ignored
- Every subsequent request went to the bare endpoint with no params
- Result: repeatedly fetched page 1, whose \`next\` still pointed to page 2 → infinite loop

## Solution

**After (fixed):**
\`\`\`python
from urllib.parse import parse_qsl, urlparse

parsed = urlparse(next_url)
next_endpoint = parsed.path.replace("/api/controller/v2/", "")
next_params = dict(parse_qsl(parsed.query))  # ✅ Extract query params

# Defensive guard against infinite loops
if next_endpoint == endpoint and next_params == params:
    logger.warning("pagination_no_progress", ...)
    break

endpoint = next_endpoint
params = next_params  # ✅ Apply extracted params
\`\`\`

**Key changes:**
1. Use \`parse_qsl()\` to extract query parameters from \`next\` URL
2. Apply those parameters to the next request
3. Add defensive guard to detect and break infinite loops

## Testing

**Manual verification:**
- Tested with 1067 groups across multiple inventories
- Pagination now correctly advances: page 1 → page 2 → page 3 → ...
- Pre-check completes in reasonable time (seconds instead of 90+ minutes)
- Defensive guard logs warning if infinite loop detected

**Affected operations:**
- Pre-check for inventories (>100 items)
- Pre-check for groups (>100 items)
- Pre-check for hosts (>100 items)
- Any \`list_resources()\` call with >100 results

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Added defensive guard for edge cases
- [x] Added explanatory comments
- [x] Tested with customer-reported scenario (1067 groups)
- [ ] Updated tests (if applicable)

## Related Issues

Closes #97

## Additional Context

This bug was discovered through customer debugging where import was stuck for 90+ minutes with no progress. Analysis of API logs showed identical GET requests being made repeatedly, leading to the discovery of the pagination bug.

Credit to customer's AI analysis for identifying the root cause.