### PR TITLE
Docs/token and url guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,17 +6,20 @@ AAP_BRIDGE_LOG_LEVEL=INFO
 
 # Source and target versions must be defined.
 
-# All AAP versions from 1.0 to 2.6 are supported.
+# All AAP versions from 1.0 to 2.6 are supported as sources; 2.6+ as targets.
 SOURCE__VERSION="2.x"
 
-# 2.6 is supported.
+# 2.6+ is supported as a target.
 TARGET__VERSION="2.6"
 
 # ============================================================================
 # Source AAP Configuration
 # ============================================================================
-# IMPORTANT: Must include /api/v2 path for AAP API
+# IMPORTANT: AAP 1.0–2.4 use /api/v2; AAP 2.5+ source use /api/controller/v2
+# Token scope: read-only is sufficient (export/prep only read data). The user
+# must have permission to read all resources being migrated.
 SOURCE__URL=https://<source_aap_url>/api/v2
+# SOURCE__URL=https://<source_aap_url>/api/controller/v2   # AAP 2.5+ source
 SOURCE__TOKEN="xxxxx"
 # SOURCE__TOKEN_VAULT_PATH=source    # Use instead of TOKEN for Vault-backed auth
 SOURCE__VERIFY_SSL=false
@@ -25,7 +28,9 @@ SOURCE__TIMEOUT=30
 # ============================================================================
 # Target AAP Configuration
 # ============================================================================
-# IMPORTANT: Must include /api/controller/v2 path for Platform Gateway
+# IMPORTANT: AAP 2.6+ target — must include /api/controller/v2 (Platform Gateway)
+# Token scope: read/write required (import, cleanup, and validation create and
+# modify resources). Use an admin-level user.
 TARGET__URL=https://<target_aap_url>/api/controller/v2
 TARGET__TOKEN="xxxxxx"
 # TARGET__TOKEN_VAULT_PATH=target    # Use instead of TOKEN for Vault-backed auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   inventories are already mapped when role grants are applied
 - **Error Output Simplified**: Console error output no longer renders full Rich
   tracebacks with local variable dumps; errors render as a single summary line
+- **Documentation – Token and URL Guidance**: Clarified read-only source vs
+  read/write target API tokens, source/target URL paths by AAP version (1.0–2.4
+  `/api/v2`, source 2.5+ and target 2.6+ `/api/controller/v2`), and corrected
+  `SECURITY.md` to use `SOURCE__TOKEN`/`TARGET__TOKEN`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - **CI/CD Docs Workflow**: GitHub Actions workflow added to publish MkDocs documentation
   via `gh-deploy` on push to `main`
 - **AAP Token Retrieval Docs**: `curl` commands with `jq` for retrieving API tokens from
-  AAP 2.4 and earlier (`/api/v2/tokens/`) and AAP 2.6+ (`/api/gateway/v1/tokens/`) are
+  AAP 2.4 and earlier (`/api/v2/tokens/`) and AAP 2.5+ (`/api/gateway/v1/tokens/`) are
   now documented
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ migrations (e.g., 80,000+ hosts)
 - **Idempotency**: Safely resume interrupted migrations without creating
   duplicates
 - **Broad Source Version Support**: Migrate from AAP 1.0, 1.1, 1.2, 2.0, 2.1,
-  2.2, 2.3, 2.4, 2.5, or 2.6 to a target AAP 2.6 instance
+  2.2, 2.3, 2.4, 2.5, or 2.6 to a target AAP 2.6+ instance
 - **Complete Resource Coverage**: Organizations, users, teams, credentials,
   execution environments, inventories, groups, hosts, projects, job templates,
   workflow job templates (including nodes, survey specs, and notification
@@ -53,7 +53,10 @@ The tool is organized into several key components:
 - **Hardware**: Minimum 8GB RAM recommended for large migrations
 - **Network**: Access to Source AAP, Target AAP, and the state management
   PostgreSQL database (not AAP)
-- **Credentials**: Admin access to both Source and Target AAP instances
+- **Credentials**: API tokens for source and target AAP instances. The source
+  token needs read-only scope (sufficient RBAC to read all resources being
+  migrated). The target token needs read/write scope (admin-level access to
+  create and modify resources during import and cleanup).
 - **HashiCorp Vault** (Optional but recommended): For migrating encrypted
   credentials securely
 - **Instance Groups**: Any instance groups that have RBAC role assignments on
@@ -147,35 +150,44 @@ cp .env.example .env
 
 Edit `.env` with your AAP instance details and database connection string.
 
-**Critical AAP 2.6 Note:** The Target URL must point to the **Platform Gateway**
-(`/api/controller/v2`), not the direct controller API.
+**Critical target note (AAP 2.6+):** The Target URL must point to the **Platform Gateway**
+(`/api/controller/v2`), not the direct controller API. Source AAP 2.5+ also uses
+`/api/controller/v2`; source versions 1.0–2.4 use `/api/v2`.
 
 To retrieve API tokens via the command line (take care to not get the password in your
 SHELL history):
 
 ```bash
-# AAP 2.5 and earlier
+# Source AAP — read-only scope is sufficient (export/prep only read data)
+# AAP 2.4 and earlier
 curl -k -X POST -u "<username>:<password>" \
   -H "Content-Type: application/json" \
-  -d '{"description": "CLI Token", "scope": "write"}' \
-  https://<aap_base_url>/api/v2/tokens/ | jq -r '.token'
+  -d '{"description": "CLI Source Token", "scope": "read"}' \
+  https://<source_aap_base_url>/api/v2/tokens/ | jq -r '.token'
 
-# AAP 2.6 and later (Platform Gateway)
+# AAP 2.5+ source (Platform Gateway)
 curl -k -X POST -u "<username>:<password>" \
   -H "Content-Type: application/json" \
-  -d '{"description": "CLI Token", "scope": "write"}' \
-  https://<aap_base_url>/api/gateway/v1/tokens/ | jq -r '.token'
+  -d '{"description": "CLI Source Token", "scope": "read"}' \
+  https://<source_aap_base_url>/api/gateway/v1/tokens/ | jq -r '.token'
+
+# Target AAP — read/write scope required (import, cleanup, and validation write data)
+# AAP 2.6+ (Platform Gateway)
+curl -k -X POST -u "<username>:<password>" \
+  -H "Content-Type: application/json" \
+  -d '{"description": "CLI Target Token", "scope": "write"}' \
+  https://<target_aap_base_url>/api/gateway/v1/tokens/ | jq -r '.token'
 ```
 
 ```bash
 
-# Source AAP instance
+# Source AAP instance (read-only token; AAP 1.0–2.4 use /api/v2, 2.5+ use /api/controller/v2)
 SOURCE__URL=https://source-aap.example.com/api/v2
-SOURCE__TOKEN=your_source_token
+SOURCE__TOKEN=your_source_read_token
 
-# Target AAP instance (Platform Gateway)
+# Target AAP instance (read/write token; AAP 2.6+ via Platform Gateway)
 TARGET__URL=https://target-aap.example.com/api/controller/v2
-TARGET__TOKEN=your_target_token
+TARGET__TOKEN=your_target_write_token
 
 # PostgreSQL state database (REQUIRED)
 MIGRATION_STATE_DB_PATH=postgresql://aap_migration_user:your_secure_password@localhost:5432/aap_migration
@@ -465,7 +477,7 @@ SSH keys, and secret fields will show as `$encrypted$`.
 
 ### Platform Gateway
 
-AAP 2.6 routes all API calls through the Platform Gateway at
+AAP 2.6+ routes target API calls through the Platform Gateway at
 `https://<gateway>/api/controller/v2/`. The tool automatically handles this routing.
 
 ## Project Status

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,23 +38,24 @@ AAP Bridge handles sensitive credentials during migration. Follow these
 practices:
 
 1. **Use Environment Variables**: Never hardcode tokens or passwords in
-   configuration files.
+   configuration files. Set them in a `.env` file (see `.env.example`) or export
+   them in your shell:
 
    ```bash
-   export AAP_23_TOKEN="your_source_token"
-   export AAP_26_TOKEN="your_target_token"
+   export SOURCE__TOKEN="your_source_read_token"
+   export TARGET__TOKEN="your_target_write_token"
+   ```
 
-   ```text
+   Use read-only tokens for the source AAP and read/write tokens for the target
+   AAP (see [Configuration](docs/getting-started/configuration.md#api-token-permissions)).
 
 2. **Protect Configuration Files**: Ensure `config/config.yaml` and `.env` have
-
    restrictive permissions.
 
    ```bash
    chmod 600 .env
    chmod 600 config/config.yaml
-
-   ```bash
+   ```
 
 3. **Secure State Database**: The migration state database may contain resource
    metadata. Protect access to the `state/` directory.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -15,18 +15,63 @@ cp .env.example .env
 ### Required Variables
 
 ```bash
-# Source AAP instance
+# Source AAP instance (read-only token)
+# AAP 1.0–2.4: /api/v2 — AAP 2.5+: /api/controller/v2
 SOURCE__URL=https://source-aap.example.com/api/v2
-SOURCE__TOKEN=your_source_api_token
+SOURCE__TOKEN=your_source_read_token
 
-# Target AAP instance (Platform Gateway for AAP 2.6+)
+# Target AAP instance (read/write token; AAP 2.6+ via Platform Gateway)
 TARGET__URL=https://target-aap.example.com/api/controller/v2
-TARGET__TOKEN=your_target_api_token
+TARGET__TOKEN=your_target_write_token
 
 # PostgreSQL state database
 MIGRATION_STATE_DB_PATH=postgresql://user:password@localhost:5432/aap_migration
 
 ```
+
+### Source and Target URLs
+
+| Instance | AAP version | URL path |
+| --- | --- | --- |
+| Source | 1.0–2.4 | `/api/v2` |
+| Source | 2.5+ | `/api/controller/v2` (Platform Gateway) |
+| Target | 2.6+ | `/api/controller/v2` (Platform Gateway) |
+
+### API Token Permissions
+
+| Instance | Token scope | Why |
+| --- | --- | --- |
+| Source | Read-only | Export and prep only read data from the source AAP |
+| Target | Read/write | Import, cleanup, and validation create and modify resources on the target |
+
+The source token user must still have permission to read all resources being
+migrated. The target token user needs admin-level access.
+
+To create tokens via the API (avoid putting passwords in shell history):
+
+```bash
+# Source — read-only scope
+# AAP 2.4 and earlier
+curl -k -X POST -u "<username>:<password>" \
+  -H "Content-Type: application/json" \
+  -d '{"description": "AAP Bridge Source Token", "scope": "read"}' \
+  https://<source_aap_base_url>/api/v2/tokens/ | jq -r '.token'
+
+# AAP 2.5+ source (Platform Gateway)
+curl -k -X POST -u "<username>:<password>" \
+  -H "Content-Type: application/json" \
+  -d '{"description": "AAP Bridge Source Token", "scope": "read"}' \
+  https://<source_aap_base_url>/api/gateway/v1/tokens/ | jq -r '.token'
+
+# Target (AAP 2.6+) — read/write scope via Platform Gateway
+curl -k -X POST -u "<username>:<password>" \
+  -H "Content-Type: application/json" \
+  -d '{"description": "AAP Bridge Target Token", "scope": "write"}' \
+  https://<target_aap_base_url>/api/gateway/v1/tokens/ | jq -r '.token'
+```
+
+The Platform Gateway token API (`/api/gateway/v1/tokens/`) was introduced in AAP 2.5.
+Use `/api/v2/tokens/` for AAP 2.4 and earlier.
 
 ### Optional Variables
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,6 +8,9 @@ Before installing AAP Bridge, ensure you have:
 - **PostgreSQL** database (for state management)
 - **uv** package manager (recommended) or pip
 - Network access to source and target AAP instances
+- **API tokens**: read-only scope for the source AAP (with permission to read
+  all resources being migrated); read/write scope with admin-level access for
+  the target AAP
 
 ### Hardware Requirements
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -13,21 +13,39 @@ cp .env.example .env
 Edit `.env` with your AAP credentials:
 
 ```bash
-# Source AAP instance (AAP 2.3/2.4)
+# Source AAP instance (read-only token)
+# AAP 1.0–2.4: direct controller API
 SOURCE__URL=https://source-aap.example.com/api/v2
-SOURCE__TOKEN=your_source_token
+# AAP 2.5+ source: Platform Gateway (uncomment and use instead of /api/v2)
+# SOURCE__URL=https://source-aap.example.com/api/controller/v2
+SOURCE__TOKEN=your_source_read_token
 
-# Target AAP instance (AAP 2.6+ via Platform Gateway)
+# Target AAP instance (read/write token; AAP 2.6+ via Platform Gateway)
 TARGET__URL=https://target-aap.example.com/api/controller/v2
-TARGET__TOKEN=your_target_token
+TARGET__TOKEN=your_target_write_token
 
 # PostgreSQL state database
 MIGRATION_STATE_DB_PATH=postgresql://user:password@localhost:5432/aap_migration
 ```
 
+!!! note "Source URL by version"
+    Set `SOURCE__URL` based on your source AAP version:
+
+    | Source version | `SOURCE__URL` path |
+    | --- | --- |
+    | AAP 1.0–2.4 | `/api/v2` |
+    | AAP 2.5+ | `/api/controller/v2` (Platform Gateway) |
+
+!!! note "API token scope"
+    The source token needs read-only scope (export/prep only read data). The
+    target token needs read/write scope with admin-level access for import and
+    cleanup. See [Configuration](configuration.md#api-token-permissions) for
+    details and `curl` examples.
+
 !!! warning "Platform Gateway URL"
-    For AAP 2.6+, the target URL must use `/api/controller/v2` (Platform
-    Gateway), not the direct controller API.
+    The target URL (AAP 2.6+) must use `/api/controller/v2` (Platform Gateway),
+    not the direct controller `/api/v2` path. Source AAP 2.5+ also uses
+    `/api/controller/v2`; only source versions 1.0–2.4 use `/api/v2`.
 
 ## 2. Validate Configuration
 

--- a/docs/user-guide/migration-workflow.md
+++ b/docs/user-guide/migration-workflow.md
@@ -251,7 +251,9 @@ Role Definitions (AAP 2.5+ RBAC)
 1. **Backup target AAP** - Always have a rollback plan
 2. **Test in staging** - Run migration in a test environment first
 3. **Check disk space** - Exports can be large
-4. **Verify credentials** - Ensure API tokens have admin access
+4. **Verify credentials** - Source API token has read-only scope with
+   permission to read all resources being migrated; target API token has
+   read/write scope with admin-level access to create and modify resources
 
 ### During Migration
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -17,7 +17,7 @@ Error: Connection refused to https://source-aap.example.com
 1. Verify the URL is correct in `.env`
 2. Check network connectivity: `curl -I
    https://source-aap.example.com/api/v2/ping/`
-3. Verify the API token is valid
+3. Verify the API token is valid and has read scope
 4. Check firewall rules
 
 ### Cannot connect to target AAP (Platform Gateway)
@@ -53,7 +53,11 @@ Error: 401 Unauthorized
 **Solutions:**
 
 1. Regenerate API token in AAP UI
-2. Ensure token has admin privileges
+2. Verify token scope matches the instance role:
+   - **Source**: read-only scope is sufficient; the user must be able to
+     read all resources being migrated
+   - **Target**: read/write scope with admin-level privileges is required for
+     import, cleanup, and validation
 3. Check token hasn't expired
 
 ## Database Issues


### PR DESCRIPTION
Clarify documentation around required token access and environment variables.  Fix version info to 2.4 and earlier (1.0-2.4) and 2.5+ URLs.