### PR TITLE
Fix gateway RBAC assignment export/import across API surfaces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   honour `shared.*` content types; dual-base export/import for `role_definitions`
   and role assignments; `_api_base` from export is remapped to the target host on
   import
+- **RBAC – Gateway Assignment Dedupe and Principal Resolution**: Role assignment
+  export no longer duplicates records listed on both gateway and controller APIs;
+  dedupe keeps the copy from the API surface where each assignment is created
+  (`shared.*` → gateway, `awx.*` → controller). Import resolves users and teams by
+  username/name when surrogate principal IDs differ between APIs, and custom role
+  definitions are looked up on the controller for `awx.*` assignments
 - **RBAC – Legacy Sources (1.0–2.4 → 2.6)**: Classic `users/{id}/roles/` and
   `teams/{id}/roles/` grants are converted to `role_user_assignments` and
   `role_team_assignments` on gateway targets instead of being skipped

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -57,6 +57,8 @@ in the repository.
 - Host bulk import reruns now skip already-mapped hosts and persist host progress state
 - Gateway RBAC routing for 2.5+ sources (dual-base role definitions/assignments,
   `shared.*` content types, target `_api_base` remapping)
+- Gateway RBAC assignment dedupe and principal resolution when gateway and
+  controller APIs use different surrogate IDs for the same user, team, or assignment
 - Legacy source RBAC (1.0–2.4) converted to role assignments on AAP 2.6 targets
 - Role definitions export via parallel path on AAP 2.5+ sources
 - Team member sync when team create is skipped on rerun

--- a/src/aap_migration/client/api_layout.py
+++ b/src/aap_migration/client/api_layout.py
@@ -151,18 +151,21 @@ def role_definition_api_base(
     Export stores ``_api_base`` with the source hostname to record which API
     surface the role came from. Import must remap that to the target layout's
     gateway/controller bases — not POST back to the source host.
+
+    On gateway topology, ``content_type`` determines the correct API surface
+    (``awx.*`` → controller, ``shared.*`` → gateway). The exported source base
+    must not override that routing — the same custom role can appear on both
+    APIs during export, but assignments for ``awx.*`` objects are always
+    created on the controller.
     """
+    if layout.mode is ApiMode.GATEWAY:
+        return layout.base_for_role_assignment(content_type)
+
     if exported_api_base:
         topology = api_topology_from_url(exported_api_base)
-        if topology == "gateway" and layout.gateway_base:
-            return layout.gateway_base
-        if topology == "controller" and layout.controller_base:
-            return layout.controller_base
         if topology == "legacy" and layout.legacy_base:
             return layout.legacy_base
 
-    if layout.mode is ApiMode.GATEWAY:
-        return layout.base_for_role_assignment(content_type)
     if not layout.legacy_base:
         raise ValueError("legacy_base is required for legacy API mode")
     return layout.legacy_base

--- a/src/aap_migration/migration/exporter.py
+++ b/src/aap_migration/migration/exporter.py
@@ -1856,9 +1856,10 @@ class RoleDefinitionExporter(ResourceExporter):
     Role definitions define the available RBAC roles in AAP 2.6.
     They are exported to map source roles to target roles.
 
-    On AAP 2.5+ gateway topology, custom role definitions live on the
-    controller API while platform roles live on the gateway. Both bases
-    are queried and deduplicated by name.
+    On AAP 2.5+ gateway topology, custom role definitions may appear on both
+    the gateway and controller APIs. Both bases are queried; duplicates are
+    dropped by name, preferring the controller copy for ``awx.*`` roles and
+    the gateway copy for platform ``shared.*`` roles.
     """
 
     async def get_count(self, endpoint: str, filters: dict[str, Any] | None = None) -> int:
@@ -1911,6 +1912,9 @@ class RoleDefinitionExporter(ResourceExporter):
 
         layout = self.client.api_layout
         bases = layout.role_assignment_bases()
+        # Prefer controller-first so awx.* roles keep controller source IDs.
+        if len(bases) > 1:
+            bases = tuple(reversed(bases))
         seen_names: set[str] = set()
 
         for base in bases:
@@ -1999,10 +2003,42 @@ class RoleDefinitionExporter(ResourceExporter):
 class RoleAssignmentListExporter(ResourceExporter):
     """Export role_user_assignments or role_team_assignments from all API bases.
 
-    On AAP 2.5+ gateway topology, platform assignments live under
-    /api/gateway/v1/ and automation-controller assignments under
-    /api/controller/v2/. Both are queried and merged by assignment id.
+    On AAP 2.5+ gateway topology, the same assignment may appear on both the
+    gateway and controller APIs with different surrogate primary keys and
+    principal FK values. Exports deduplicate by principal identity + content
+    object + role definition name, keeping the copy from the API surface where
+    that assignment is created (``shared.*`` → gateway, ``awx.*`` → controller).
     """
+
+    @staticmethod
+    def _assignment_dedupe_key(
+        resource: dict[str, Any], resource_type: str
+    ) -> tuple[Any, ...] | None:
+        """Logical identity for a role assignment (ignores per-API surrogate ids)."""
+        from aap_migration.client.api_layout import normalize_rbac_content_type
+
+        content_type = normalize_rbac_content_type(
+            resource.get("content_type")
+        ) or resource.get("content_type")
+        object_id = resource.get("object_id")
+        summary = resource.get("summary_fields") or {}
+        role_def_name = (summary.get("role_definition") or {}).get("name")
+        if resource_type == "role_team_assignments":
+            principal = (
+                resource.get("team_ansible_id")
+                or (summary.get("team") or {}).get("name")
+                or resource.get("team")
+            )
+        else:
+            user_summary = summary.get("user") or {}
+            principal = (
+                user_summary.get("username")
+                or resource.get("user_ansible_id")
+                or resource.get("user")
+            )
+        if not content_type or object_id is None or not role_def_name or principal is None:
+            return None
+        return (content_type, str(object_id), role_def_name, principal)
 
     async def export_parallel(
         self,
@@ -2016,6 +2052,9 @@ class RoleAssignmentListExporter(ResourceExporter):
         layout = self.client.api_layout
         bases = layout.role_assignment_bases()
         seen_ids: set[int] = set()
+        # key -> (api_base, raw resource); prefer the base where import creates assignments
+        logical_assignments: dict[tuple[Any, ...], tuple[str, dict[str, Any]]] = {}
+        id_only_resources: list[dict[str, Any]] = []
         total_fetched = 0
 
         logger.info(
@@ -2047,21 +2086,51 @@ class RoleAssignmentListExporter(ResourceExporter):
                     rid = resource.get("id")
                     if rid is not None and rid in seen_ids:
                         continue
+                    dedupe_key = self._assignment_dedupe_key(resource, resource_type)
+                    if dedupe_key is None:
+                        if rid is not None:
+                            seen_ids.add(rid)
+                        id_only_resources.append(resource)
+                        continue
+
+                    preferred_base = layout.base_for_role_assignment(
+                        resource.get("content_type")
+                    )
+                    existing = logical_assignments.get(dedupe_key)
+                    if existing is None:
+                        logical_assignments[dedupe_key] = (base, resource)
+                    else:
+                        existing_base, _ = existing
+                        if base == preferred_base and existing_base != preferred_base:
+                            logical_assignments[dedupe_key] = (base, resource)
                     if rid is not None:
                         seen_ids.add(rid)
-                    processed = await self._process_resource(resource, resource_type)
-                    if processed:
-                        if processed.get("_skipped"):
-                            self.stats["skipped_count"] += 1
-                            yield processed
-                        else:
-                            self.stats["exported_count"] += 1
-                            total_fetched += 1
-                            yield processed
 
                 if not response.get("next") or not results:
                     break
                 page += 1
+
+        for resource in id_only_resources:
+            processed = await self._process_resource(resource, resource_type)
+            if processed:
+                if processed.get("_skipped"):
+                    self.stats["skipped_count"] += 1
+                    yield processed
+                else:
+                    self.stats["exported_count"] += 1
+                    total_fetched += 1
+                    yield processed
+
+        for _, resource in logical_assignments.values():
+            processed = await self._process_resource(resource, resource_type)
+            if processed:
+                if processed.get("_skipped"):
+                    self.stats["skipped_count"] += 1
+                    yield processed
+                else:
+                    self.stats["exported_count"] += 1
+                    total_fetched += 1
+                    yield processed
 
         logger.info(
             "role_assignment_export_completed",

--- a/src/aap_migration/migration/importer.py
+++ b/src/aap_migration/migration/importer.py
@@ -5097,6 +5097,24 @@ async def _resolve_role_definition_target_id(
     (shared.*) live on different API bases — lookups must use the same base as
     the assignment being created.
     """
+    lookup_base = role_definition_api_base(client.api_layout, content_type, api_base)
+
+    if role_def_name:
+        try:
+            results = await client.get_on_base(
+                lookup_base, "role_definitions/", params={"name": role_def_name}
+            )
+            resources = results.get("results", [])
+            if resources:
+                return resources[0]["id"]
+        except Exception as e:
+            logger.error(
+                "role_definition_name_lookup_failed",
+                role_def_name=role_def_name,
+                api_base=lookup_base,
+                error=str(e),
+            )
+
     target_id = state.get_mapped_id("role_definitions", role_def_source_id)
     if target_id:
         return target_id
@@ -5109,23 +5127,6 @@ async def _resolve_role_definition_target_id(
         )
         return None
 
-    lookup_base = role_definition_api_base(client.api_layout, content_type, api_base)
-
-    try:
-        results = await client.get_on_base(
-            lookup_base, "role_definitions/", params={"name": role_def_name}
-        )
-        resources = results.get("results", [])
-        if resources:
-            return resources[0]["id"]
-    except Exception as e:
-        logger.error(
-            "role_definition_name_lookup_failed",
-            role_def_name=role_def_name,
-            api_base=lookup_base,
-            error=str(e),
-        )
-
     logger.warning(
         "role_definition_not_found_on_target",
         role_def_name=role_def_name,
@@ -5134,6 +5135,53 @@ async def _resolve_role_definition_target_id(
         api_base=lookup_base,
     )
     return None
+
+
+def _resolve_user_target_id_for_assignment(
+    state: Any,
+    assignment: dict[str, Any],
+    user_source_id: Any,
+) -> int | None:
+    """Resolve target user ID for a role_user_assignment.
+
+    Gateway user exports use gateway surrogate IDs, but the same assignment can
+    be listed from the controller API with a different user FK. Prefer username
+    from export/transform when available.
+    """
+    username = assignment.get("user_username")
+    if username:
+        mapping = state.get_mapping_by_name("users", str(username))
+        if mapping and mapping.target_id:
+            return int(mapping.target_id)
+
+    if user_source_id is None:
+        return None
+    try:
+        source_id = int(user_source_id)
+    except (TypeError, ValueError):
+        return None
+    return state.get_mapped_id("users", source_id)
+
+
+def _resolve_team_target_id_for_assignment(
+    state: Any,
+    assignment: dict[str, Any],
+    team_source_id: Any,
+) -> int | None:
+    """Resolve target team ID for a role_team_assignment."""
+    team_name = assignment.get("team_name")
+    if team_name:
+        mapping = state.get_mapping_by_name("teams", str(team_name))
+        if mapping and mapping.target_id:
+            return int(mapping.target_id)
+
+    if team_source_id is None:
+        return None
+    try:
+        source_id = int(team_source_id)
+    except (TypeError, ValueError):
+        return None
+    return state.get_mapped_id("teams", source_id)
 
 
 class RoleUserAssignmentImporter(ResourceImporter):
@@ -5215,7 +5263,9 @@ class RoleUserAssignmentImporter(ResourceImporter):
                 continue
 
             # Resolve user
-            target_user_id = self.state.get_mapped_id("users", user_source_id)
+            target_user_id = _resolve_user_target_id_for_assignment(
+                self.state, assignment, user_source_id
+            )
             if not target_user_id:
                 logger.warning(
                     "role_assignment_user_not_found",
@@ -5331,7 +5381,9 @@ class RoleTeamAssignmentImporter(ResourceImporter):
                 continue
 
             # Resolve team
-            target_team_id = self.state.get_mapped_id("teams", team_source_id)
+            target_team_id = _resolve_team_target_id_for_assignment(
+                self.state, assignment, team_source_id
+            )
             if not target_team_id:
                 logger.warning(
                     "role_assignment_team_not_found",

--- a/src/aap_migration/migration/transformer.py
+++ b/src/aap_migration/migration/transformer.py
@@ -2321,6 +2321,13 @@ class RoleAssignmentTransformer(DataTransformer):
         if content_obj and content_obj.get("name"):
             data["content_object_name"] = content_obj["name"]
 
+        user_summary = summary.get("user") or {}
+        if user_summary.get("username"):
+            data["user_username"] = user_summary["username"]
+        team_summary = summary.get("team") or {}
+        if team_summary.get("name"):
+            data["team_name"] = team_summary["name"]
+
         content_type = data.get("content_type")
         if content_type:
             data["content_type"] = normalize_rbac_content_type(content_type) or content_type

--- a/tests/unit/test_rbac_import.py
+++ b/tests/unit/test_rbac_import.py
@@ -57,6 +57,16 @@ class TestRoleDefinitionApiBase:
             "https://aap25.example.com/api/controller/v2",
         ) == ("https://aap.example.com/api/controller/v2")
 
+    def test_gateway_exported_automation_role_uses_target_controller(self) -> None:
+        layout = self._gateway_layout()
+        # awx.* roles may be listed from the gateway API during export, but
+        # assignments are created on the controller — lookups must follow.
+        assert role_definition_api_base(
+            layout,
+            "awx.project",
+            "https://aap25.example.com/api/gateway/v1",
+        ) == ("https://aap.example.com/api/controller/v2")
+
     def test_exported_source_api_base_maps_to_target_gateway(self) -> None:
         layout = self._gateway_layout()
         assert role_definition_api_base(
@@ -64,3 +74,46 @@ class TestRoleDefinitionApiBase:
             "shared.organization",
             "https://aap25.example.com/api/gateway/v1",
         ) == ("https://aap.example.com/api/gateway/v1")
+
+
+class TestRoleAssignmentDedupeKey:
+    def test_user_assignment_key_uses_username_not_controller_fk(self) -> None:
+        from aap_migration.migration.exporter import RoleAssignmentListExporter
+
+        resource = {
+            "content_type": "shared.organization",
+            "object_id": "1",
+            "user": 47,
+            "user_ansible_id": "fb4a1b19-46d2-43ec-8627-9dbb21683e80",
+            "summary_fields": {
+                "role_definition": {"name": "Organization Member"},
+                "user": {"id": 47, "username": "jadoe"},
+            },
+        }
+        key = RoleAssignmentListExporter._assignment_dedupe_key(
+            resource, "role_user_assignments"
+        )
+        assert key == ("awx.organization", "1", "Organization Member", "jadoe")
+
+
+class TestResolveUserTargetIdForAssignment:
+    def test_prefers_username_over_mismatched_source_fk(self) -> None:
+        from unittest.mock import MagicMock
+
+        from aap_migration.migration.importer import _resolve_user_target_id_for_assignment
+
+        state = MagicMock()
+        mapping = MagicMock()
+        mapping.target_id = 11
+        state.get_mapping_by_name.return_value = mapping
+        state.get_mapped_id.return_value = 10
+
+        target_id = _resolve_user_target_id_for_assignment(
+            state,
+            {"user_username": "jadoe", "user": 47},
+            47,
+        )
+
+        assert target_id == 11
+        state.get_mapping_by_name.assert_called_once_with("users", "jadoe")
+        state.get_mapped_id.assert_not_called()


### PR DESCRIPTION
Deduplicate role assignments by principal identity and route each to the correct gateway or controller API so custom roles and user mappings are not lost when surrogate IDs differ between surfaces.