### PR TITLE
Redact database credentials from migration logs.

### DIFF
--- a/src/aap_migration/cli/context.py
+++ b/src/aap_migration/cli/context.py
@@ -13,7 +13,7 @@ from aap_migration.client.aap_target_client import AAPTargetClient
 from aap_migration.client.vault_client import VaultClient
 from aap_migration.config import AAPInstanceConfig, MigrationConfig, load_config_from_yaml
 from aap_migration.migration.state import MigrationState
-from aap_migration.utils.logging import get_logger
+from aap_migration.utils.logging import get_logger, redact_database_url
 
 logger = get_logger(__name__)
 
@@ -156,7 +156,7 @@ class MigrationContext:
         if self._migration_state is None:
             logger.debug(
                 "Initializing migration state",
-                db_path=str(self.config.state.db_path),
+                db_path=redact_database_url(str(self.config.state.db_path)),
             )
             self._migration_state = MigrationState(
                 config=self.config.state,

--- a/src/aap_migration/migration/database.py
+++ b/src/aap_migration/migration/database.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from aap_migration.client.exceptions import ConfigurationError, StateError
 from aap_migration.migration.models import Base
-from aap_migration.utils.logging import get_logger
+from aap_migration.utils.logging import get_logger, redact_database_url
 
 logger = get_logger(__name__)
 
@@ -116,7 +116,11 @@ def create_database_engine(
         return engine
 
     except Exception as e:
-        logger.error("Failed to create database engine", error=str(e), database_url=database_url)
+        logger.error(
+            "Failed to create database engine",
+            error=str(e),
+            database_url=redact_database_url(database_url),
+        )
         raise ConfigurationError(f"Failed to create database engine: {e}") from e
 
 
@@ -169,14 +173,18 @@ def init_database(
 
         logger.info(
             "Database initialized successfully",
-            database_url=database_url,
+            database_url=redact_database_url(database_url),
             tables=len(Base.metadata.tables),
         )
 
         return _engine
 
     except Exception as e:
-        logger.error("Failed to initialize database", error=str(e), database_url=database_url)
+        logger.error(
+            "Failed to initialize database",
+            error=str(e),
+            database_url=redact_database_url(database_url),
+        )
         raise ConfigurationError(f"Failed to initialize database: {e}") from e
 
 
@@ -292,17 +300,23 @@ def reset_database(database_url: str) -> None:
 
         # Drop all tables
         Base.metadata.drop_all(engine)
-        logger.warning("All database tables dropped", database_url=database_url)
+        logger.warning(
+            "All database tables dropped", database_url=redact_database_url(database_url)
+        )
 
         # Recreate all tables
         Base.metadata.create_all(engine)
-        logger.info("Database tables recreated", database_url=database_url)
+        logger.info("Database tables recreated", database_url=redact_database_url(database_url))
 
         # Dispose of the engine
         engine.dispose()
 
     except Exception as e:
-        logger.error("Failed to reset database", error=str(e), database_url=database_url)
+        logger.error(
+            "Failed to reset database",
+            error=str(e),
+            database_url=redact_database_url(database_url),
+        )
         raise ConfigurationError(f"Failed to reset database: {e}") from e
 
 
@@ -322,12 +336,17 @@ def validate_database_connection(database_url: str) -> bool:
             # Execute a simple query to verify connection
             conn.execute(text("SELECT 1"))
         engine.dispose()
-        logger.info("Database connection validated successfully", database_url=database_url)
+        logger.info(
+            "Database connection validated successfully",
+            database_url=redact_database_url(database_url),
+        )
         return True
 
     except Exception as e:
         logger.error(
-            "Database connection validation failed", error=str(e), database_url=database_url
+            "Database connection validation failed",
+            error=str(e),
+            database_url=redact_database_url(database_url),
         )
         return False
 

--- a/src/aap_migration/migration/state.py
+++ b/src/aap_migration/migration/state.py
@@ -22,7 +22,7 @@ from aap_migration.migration.models import (
     IDMapping,
     MigrationProgress,
 )
-from aap_migration.utils.logging import get_logger
+from aap_migration.utils.logging import get_logger, redact_database_url
 
 logger = get_logger(__name__)
 
@@ -127,7 +127,7 @@ class MigrationState:
             logger.info(
                 "Migration state initialized",
                 migration_id=self.migration_id,
-                database_path=config.db_path,
+                database_path=redact_database_url(config.db_path),
             )
         except Exception as e:
             logger.error("Failed to initialize migration state", error=str(e))

--- a/src/aap_migration/utils/logging.py
+++ b/src/aap_migration/utils/logging.py
@@ -313,6 +313,36 @@ def log_error(
     )
 
 
+def redact_database_url(url: str) -> str:
+    """Redact credentials from a database connection URL for safe logging.
+
+    PostgreSQL and MySQL URLs with embedded credentials are masked; SQLite
+    paths are returned unchanged.
+
+    Args:
+        url: Database connection URL or file path
+
+    Returns:
+        URL with username and password replaced by ``***``, or the original value for SQLite
+    """
+    if not url or url.startswith("sqlite"):
+        return url
+
+    from urllib.parse import urlparse, urlunparse
+
+    try:
+        parsed = urlparse(url)
+        if not parsed.username and not parsed.password:
+            return url
+
+        host = parsed.hostname or ""
+        port = f":{parsed.port}" if parsed.port else ""
+        netloc = f"***@{host}{port}"
+        return urlunparse(parsed._replace(netloc=netloc))
+    except Exception:
+        return "[REDACTED]"
+
+
 def sanitize_payload(payload: dict[str, Any] | list[Any] | Any, max_depth: int = 10) -> Any:
     """Sanitize sensitive fields in API payloads before logging.
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,23 @@
+"""Tests for logging utilities."""
+
+from aap_migration.utils.logging import redact_database_url
+
+
+def test_redact_database_url_masks_postgresql_password():
+    url = "postgresql://aap_migration_user:redhat@localhost:5432/aap_migration"
+    assert redact_database_url(url) == "postgresql://***@localhost:5432/aap_migration"
+
+
+def test_redact_database_url_leaves_sqlite_unchanged():
+    url = "sqlite:///data/state.db"
+    assert redact_database_url(url) == url
+
+
+def test_redact_database_url_leaves_url_without_credentials_unchanged():
+    url = "postgresql://localhost:5432/aap_migration"
+    assert redact_database_url(url) == url
+
+
+def test_redact_database_url_masks_mysql_password():
+    url = "mysql://dbuser:s3cret@db.example.com/mydb"
+    assert redact_database_url(url) == "mysql://***@db.example.com/mydb"


### PR DESCRIPTION
Phase 2 export and state initialization were logging full PostgreSQL connection strings including usernames and passwords.

Fixes https://github.com/redhat-cop/aap-bridge/issues/118.