### PR TITLE
Continue workflow import when individual resources fail.

### DIFF
--- a/src/aap_migration/migration/importer.py
+++ b/src/aap_migration/migration/importer.py
@@ -4245,21 +4245,31 @@ class WorkflowImporter(ResourceImporter):
             # Extract nodes for separate import
             nodes = workflow.pop("_workflow_job_template_nodes", None)
 
-            result = await self.import_resource(
-                resource_type="workflow_job_templates",
-                source_id=source_id,
-                data=workflow,
-            )
+            try:
+                result = await self.import_resource(
+                    resource_type="workflow_job_templates",
+                    source_id=source_id,
+                    data=workflow,
+                )
 
-            if result:
-                if nodes:
-                    for node in nodes:
-                        if isinstance(node, dict):
-                            pending_nodes.append(dict(node))
-                results.append(result)
-                success_count += 1
-            else:
+                if result:
+                    if nodes:
+                        for node in nodes:
+                            if isinstance(node, dict):
+                                pending_nodes.append(dict(node))
+                    results.append(result)
+                    success_count += 1
+                else:
+                    failed_count += 1
+
+            except Exception as e:
                 failed_count += 1
+                logger.error(
+                    "workflow_import_failed",
+                    source_id=source_id,
+                    name=workflow.get("name"),
+                    error=str(e),
+                )
 
             # Update progress after each workflow
             if progress_callback:

--- a/tests/unit/test_importer.py
+++ b/tests/unit/test_importer.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aap_migration.client.aap_target_client import AAPTargetClient
-from aap_migration.client.exceptions import APIError, ConflictError
+from aap_migration.client.exceptions import APIError, AuthorizationError, ConflictError
 from aap_migration.config import PerformanceConfig
 from aap_migration.migration.importer import (
     CredentialImporter,
@@ -734,6 +734,31 @@ class TestWorkflowImporter:
         # Nodes should not be in the create call
         call_args = mock_client.create_resource.call_args_list[0][1]["data"]
         assert "_workflow_job_template_nodes" not in call_args
+
+    @pytest.mark.asyncio
+    async def test_import_workflows_continues_after_api_error(self, workflow_importer, mock_client):
+        """A single workflow failure must not abort the remaining imports."""
+        mock_client.create_resource = AsyncMock(
+            side_effect=[
+                AuthorizationError(
+                    message="Authorization failed",
+                    status_code=403,
+                    response={"detail": "Forbidden"},
+                ),
+                {"id": 601, "name": "Workflow Two"},
+            ]
+        )
+
+        workflows = [
+            {"_source_id": 1, "name": "Workflow One", "organization": 1},
+            {"_source_id": 2, "name": "Workflow Two", "organization": 1},
+        ]
+
+        results = await workflow_importer.import_workflows(workflows)
+
+        assert len(results) == 1
+        assert results[0]["id"] == 601
+        assert mock_client.create_resource.call_count == 2
 
     @pytest.mark.asyncio
     async def test_import_workflow_posts_survey_spec(self, workflow_importer, mock_client):


### PR DESCRIPTION
Match job template error handling so a single workflow 403 does not abort the entire Phase 2 import batch.

Relates to https://github.com/redhat-cop/aap-bridge/issues/111.